### PR TITLE
:seedling: pass by the container image used in run.sh

### DIFF
--- a/bundles/bundles.go
+++ b/bundles/bundles.go
@@ -177,7 +177,10 @@ func (l *ContainerRunner) Install(config *BundleConfig) error {
 	}
 
 	// We want to expect tempDir as context
-	out, err = utils.SHInDir(fmt.Sprintf("CONTAINERDIR=%s %s/run.sh", tempDir, tempDir), tempDir)
+	out, err = utils.SHInDir(
+		filepath.Join(tempDir, "run.sh"),
+		tempDir,
+		fmt.Sprintf("CONTAINERDIR=%s", tempDir), fmt.Sprintf("BUNDLE_TARGET=%s", target))
 	if err != nil {
 		return fmt.Errorf("could not execute container: %w - %s", err, out)
 	}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -2,10 +2,11 @@ package utils
 
 import (
 	"fmt"
-	"github.com/denisbrodbeck/machineid"
-	"github.com/joho/godotenv"
 	"os"
 	"os/exec"
+
+	"github.com/denisbrodbeck/machineid"
+	"github.com/joho/godotenv"
 )
 
 func SH(c string) (string, error) {
@@ -15,9 +16,9 @@ func SH(c string) (string, error) {
 	return string(o), err
 }
 
-func SHInDir(c, dir string) (string, error) {
+func SHInDir(c, dir string, envs ...string) (string, error) {
 	cmd := exec.Command("/bin/sh", "-c", c)
-	cmd.Env = os.Environ()
+	cmd.Env = append(os.Environ(), envs...)
 	cmd.Dir = dir
 	o, err := cmd.CombinedOutput()
 	return string(o), err


### PR DESCRIPTION
so a bundle knows which image was pulled. useful to pass by and create plans (we use it for coco)