### PR TITLE
Semi force the umount of oem when dealing with mounts

### DIFF
--- a/system/cloudconfig.go
+++ b/system/cloudconfig.go
@@ -35,14 +35,11 @@ func addCloudConfig(cloudConfig, filename string) error {
 
 func writeCloudConfig(oem state.PartitionState, cloudConfig, subpath, filename string) error {
 	mountPath := "/tmp/oem"
+	defer mounts.Umount(state.PartitionState{Mounted: true, MountPoint: mountPath}) //nolint:errcheck
 
 	if err := mounts.PrepareWrite(oem, mountPath); err != nil {
 		return err
 	}
-	defer func() {
-		oem.MountPoint = mountPath
-		mounts.Umount(oem) //nolint:errcheck
-	}()
 	_ = os.MkdirAll(filepath.Join(mountPath, subpath), 0650)
 	return os.WriteFile(filepath.Join(mountPath, subpath, fmt.Sprintf("%s.yaml", filename)), []byte(cloudConfig), 0650)
 }

--- a/system/grub.go
+++ b/system/grub.go
@@ -19,6 +19,7 @@ func SetGRUBOptions(opts map[string]string) Option {
 
 func setGRUBOptions(opts map[string]string) error {
 	mountPath := "/tmp/oem"
+	defer mounts.Umount(state.PartitionState{Mounted: true, MountPoint: mountPath}) //nolint:errcheck
 	runtime, err := state.NewRuntime()
 	if err != nil {
 		return err
@@ -32,10 +33,6 @@ func setGRUBOptions(opts map[string]string) error {
 	if err := mounts.PrepareWrite(oem, mountPath); err != nil {
 		return err
 	}
-	defer func() {
-		oem.MountPoint = mountPath
-		mounts.Umount(oem) //nolint:errcheck
-	}()
 
 	for k, v := range opts {
 		out, err := utils.SH(fmt.Sprintf(`%s /tmp/oem/grubenv set "%s=%s"`, utils.FindCommand("grub2-editenv", []string{"grub2-editenv", "grub-editenv"}), k, v))


### PR DESCRIPTION
Seems that the current state could lead to leave oem mounted.

This patch makes it so the umount is defered from the start of the function and that we semi-force it to try to umount oem no matter the current state.

Fixes https://github.com/kairos-io/kairos/issues/1673