### PR TITLE
Add KairosFS type and detectBoot with FS

### DIFF
--- a/types/fs.go
+++ b/types/fs.go
@@ -1,0 +1,7 @@
+package types
+
+// KairosFS is our interface for methods that need an FS
+// We should try to keep it to a minimum so we can change between backends easily if needed
+type KairosFS interface {
+	ReadFile(filename string) ([]byte, error)
+}


### PR DESCRIPTION
Adds teh KairosFS interface for FS that our methods are gonna use with a minimal set that we cna grow over time if needed.

For now, its useful to methods that act on a fs and we may want to mock that fs for testing.

Current interface should be already implemented in vfs directly