### PR TITLE
feat: add ProviderOptions to Cluster

### DIFF
--- a/clusterplugin/config.go
+++ b/clusterplugin/config.go
@@ -48,8 +48,12 @@ type Cluster struct {
 	// Role informs the sdk what kind of installation to manage on this device.
 	Role Role `yaml:"role,omitempty" json:"role,omitempty"`
 
-	// Options are arbitrary values the sdk may be interested in.  These values are not validated by Kairos and are simply forwarded to the sdk.
+	// Options are arbitrary values the sdk may be interested in. These values are not validated by Kairos and are simply forwarded to the sdk.
 	Options string `yaml:"config,omitempty" json:"config,omitempty"`
+
+	// ProviderOptions are arbitrary, provider-specific values the sdk may be interested in. These values are not validated by Kairos and are simply forwarded to the sdk.
+	// ProviderOptions are meant to handle non-cluster values, while Options can be used for cluster-specific configuration values.
+	ProviderOptions map[string]string `yaml:"providerConfig,omitempty" json:"providerConfig,omitempty"`
 
 	// Env contains the list of environment variables to be set on the cluster
 	Env map[string]string `yaml:"env,omitempty" json:"env,omitempty"`


### PR DESCRIPTION
Currently, provider-k3s splits k3s configuration between:
* `/etc/rancher/k3s/config.d/99_userdata.yaml` and
* `/etc/rancher/k3s/config.d/90_userdata.yaml`

The two files are merged to create `/etc/rancher/k3s/config.yaml`.

Values in `90_userdata.yaml` are user-configurable on the Palette UI and are constructed entirely from `Cluster.Options`. 
Values in `99_userdata.yaml` are constructed statically by provider-k3s from other fields of the `Cluster` struct.

This prevents disabling `cluster-init` to use sqlite instead of etcd, because even if I define `cluster-init: "false"` in the user options, it is merged with `cluster-init: "true"` in the provider config, resulting in `cluster-init: "falsetrue"` in `/etc/rancher/k3s/config.yaml`.

Therefore I propose adding `ProviderOptions` to add optionality to the non-user-facing k3s configuration.

Currently I am [keying off of a random environment variable](https://github.com/kairos-io/provider-k3s/pull/65/files#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R38) as there is no other choice.