### PR TITLE
Don't parse userdata and userdata.yaml

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -255,7 +255,7 @@ func parseFiles(dir []string, nologs bool) Configs {
 			}
 			continue
 		}
-		if strings.Contains(f, "userdata") || filepath.Ext(f) == ".yml" || filepath.Ext(f) == ".yaml" {
+		if filepath.Ext(f) == ".yml" || filepath.Ext(f) == ".yaml" {
 			b, err := os.ReadFile(f)
 			if err != nil {
 				if !nologs {


### PR DESCRIPTION
yip writes both files with the same content when userdata passes validation (schema.Load):

https://github.com/mudler/yip/blob/48147fae9dbcc91559cd590976816ca3f65a3bff/pkg/plugins/datasource.go#L246-L252

This means we shouldn't match `userdata` since the `userdata.yaml` will be used due to the extension.

Fixes https://github.com/kairos-io/kairos/issues/2019