### PR TITLE
Remove variant from base tag

### DIFF
--- a/versioneer/base_name_test.go
+++ b/versioneer/base_name_test.go
@@ -28,7 +28,7 @@ var _ = Describe("BaseContainerName", func() {
 		BeforeEach(func() {
 			id = "master"
 			registryAndOrg = "quay.io/kairos"
-			expectedName = "quay.io/kairos/opensuse:leap-15.5-standard-amd64-generic-master"
+			expectedName = "quay.io/kairos/opensuse:leap-15.5-amd64-generic-master"
 		})
 		It("returns the name", func() {
 			name, err := artifact.BaseContainerName(registryAndOrg, id)

--- a/versioneer/versioneer.go
+++ b/versioneer/versioneer.go
@@ -139,7 +139,14 @@ func (a *Artifact) BaseContainerName(registryAndOrg, id string) (string, error) 
 }
 
 func (a *Artifact) BaseTag() (string, error) {
-	return a.commonName()
+	if err := a.Validate(); err != nil {
+		return "", err
+	}
+
+	result := fmt.Sprintf("%s-%s-%s",
+		a.FlavorRelease, a.Arch, a.Model)
+
+	return result, nil
 }
 
 func (a *Artifact) Tag() (string, error) {


### PR DESCRIPTION
My bad, when I originally added the base-image function to naming.sh I included this bug, I have already fixed it on naming.sh so here is the PR to keep them in sync