### PR TITLE
Make "standard" flavor os-release variables optional

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -28,6 +28,14 @@ const (
 	unknown = "unknown"
 )
 
+type KeyNotFoundErr struct {
+	Err error
+}
+
+func (err KeyNotFoundErr) Error() string {
+	return err.Err.Error()
+}
+
 func SH(c string) (string, error) {
 	cmd := exec.Command("/bin/sh", "-c", c)
 	cmd.Env = os.Environ()
@@ -83,7 +91,7 @@ func OSRelease(key string, file ...string) (string, error) {
 		// We try with the old naming without the prefix in case the key wasn't found
 		v, exists = release[key]
 		if !exists {
-			return "", fmt.Errorf("%s key not found", kairosKey)
+			return "", KeyNotFoundErr{Err: fmt.Errorf("%s key not found", kairosKey)}
 		}
 	}
 	return v, nil

--- a/versioneer/cli.go
+++ b/versioneer/cli.go
@@ -56,6 +56,13 @@ var (
 		EnvVars: []string{EnvVarSoftwareVersion},
 	}
 
+	softwareVersionPrefixFlag *cli.StringFlag = &cli.StringFlag{
+		Name:    "software-version-prefix",
+		Value:   "",
+		Usage:   "the string that separates the Kairos version from the software version (e.g. \"k3s\")",
+		EnvVars: []string{EnvVarSoftwareVersionPrefix},
+	}
+
 	registryAndOrgFlag *cli.StringFlag = &cli.StringFlag{
 		Name:    "registry-and-org",
 		Value:   "",
@@ -99,7 +106,7 @@ func CliCommands() []*cli.Command {
 			Usage: "generates an artifact name for Kairos OCI images",
 			Flags: []cli.Flag{
 				flavorFlag, flavorReleaseFlag, variantFlag, modelFlag, archFlag,
-				versionFlag, softwareVersionFlag, registryAndOrgFlag,
+				versionFlag, softwareVersionFlag, softwareVersionPrefixFlag, registryAndOrgFlag,
 			},
 			Action: func(cCtx *cli.Context) error {
 				a := artifactFromFlags(cCtx)
@@ -118,7 +125,7 @@ func CliCommands() []*cli.Command {
 			Usage: "generates a name for bootable artifacts (e.g. iso files)",
 			Flags: []cli.Flag{
 				flavorFlag, flavorReleaseFlag, variantFlag, modelFlag, archFlag,
-				versionFlag, softwareVersionFlag,
+				versionFlag, softwareVersionFlag, softwareVersionPrefixFlag,
 			},
 			Action: func(cCtx *cli.Context) error {
 				a := artifactFromFlags(cCtx)
@@ -157,7 +164,7 @@ func CliCommands() []*cli.Command {
 			Usage: "generates a set of variables to be appended in the /etc/os-release file",
 			Flags: []cli.Flag{
 				flavorFlag, flavorReleaseFlag, variantFlag, modelFlag, archFlag, versionFlag,
-				softwareVersionFlag, registryAndOrgFlag, bugReportURLFlag, projectHomeURLFlag,
+				softwareVersionFlag, softwareVersionPrefixFlag, registryAndOrgFlag, bugReportURLFlag, projectHomeURLFlag,
 				githubRepoFlag,
 			},
 			Action: func(cCtx *cli.Context) error {
@@ -182,12 +189,13 @@ func CliCommands() []*cli.Command {
 
 func artifactFromFlags(cCtx *cli.Context) Artifact {
 	return Artifact{
-		Flavor:          flavorFlag.Get(cCtx),
-		FlavorRelease:   flavorReleaseFlag.Get(cCtx),
-		Variant:         variantFlag.Get(cCtx),
-		Model:           modelFlag.Get(cCtx),
-		Arch:            archFlag.Get(cCtx),
-		Version:         versionFlag.Get(cCtx),
-		SoftwareVersion: softwareVersionFlag.Get(cCtx),
+		Flavor:                flavorFlag.Get(cCtx),
+		FlavorRelease:         flavorReleaseFlag.Get(cCtx),
+		Variant:               variantFlag.Get(cCtx),
+		Model:                 modelFlag.Get(cCtx),
+		Arch:                  archFlag.Get(cCtx),
+		Version:               versionFlag.Get(cCtx),
+		SoftwareVersion:       softwareVersionFlag.Get(cCtx),
+		SoftwareVersionPrefix: softwareVersionPrefixFlag.Get(cCtx),
 	}
 }

--- a/versioneer/new_from_os_release_test.go
+++ b/versioneer/new_from_os_release_test.go
@@ -20,7 +20,7 @@ var _ = Describe("NewArtifactFromOSRelease", func() {
 		osReleaseContent = "KAIROS_FLAVOR=opensuse\n" +
 			"KAIROS_FLAVOR_RELEASE=leap-15.5\n" +
 			"KAIROS_VARIANT=standard\n" +
-			"KAIROS_ARCH=amd64\n" +
+			"KAIROS_TARGETARCH=amd64\n" +
 			"KAIROS_MODEL=generic\n" +
 			"KAIROS_RELEASE=v2.4.2\n" +
 			"KAIROS_SOFTWARE_VERSION=v1.26.9+k3s1\n" +

--- a/versioneer/versioneer.go
+++ b/versioneer/versioneer.go
@@ -251,6 +251,9 @@ func (a *Artifact) OSReleaseVariables(registryAndOrg, githubRepo, bugURL, homeUR
 	if a.SoftwareVersion != "" {
 		vars["KAIROS_SOFTWARE_VERSION"] = a.SoftwareVersion
 	}
+	if a.SoftwareVersionPrefix != "" {
+		vars["KAIROS_SOFTWARE_VERSION_PREFIX"] = a.SoftwareVersionPrefix
+	}
 
 	result := ""
 	for k, v := range vars {

--- a/versioneer/versioneer.go
+++ b/versioneer/versioneer.go
@@ -18,7 +18,7 @@ const (
 	EnvVarFlavorRelease         = "FLAVOR_RELEASE"
 	EnvVarVariant               = "VARIANT"
 	EnvVarModel                 = "MODEL"
-	EnvVarArch                  = "ARCH"
+	EnvVarArch                  = "TARGETARCH"
 	EnvVarSoftwareVersion       = "SOFTWARE_VERSION"
 	EnvVarSoftwareVersionPrefix = "SOFTWARE_VERSION_PREFIX"
 	EnvVarRegistryAndOrg        = "REGISTRY_AND_ORG"
@@ -74,10 +74,16 @@ func NewArtifactFromOSRelease(file ...string) (*Artifact, error) {
 	if result.Version, err = utils.OSRelease(EnvVarVersion, file...); err != nil {
 		return nil, err
 	}
-	if result.SoftwareVersion, err = utils.OSRelease(EnvVarSoftwareVersion, file...); err != nil {
+
+	// Optional, could be missing
+	result.SoftwareVersion, err = utils.OSRelease(EnvVarSoftwareVersion, file...)
+	if err != nil && !errors.As(err, &utils.KeyNotFoundErr{}) {
 		return nil, err
 	}
-	if result.SoftwareVersionPrefix, err = utils.OSRelease(EnvVarSoftwareVersionPrefix, file...); err != nil {
+
+	// Optional, could be missing
+	result.SoftwareVersionPrefix, err = utils.OSRelease(EnvVarSoftwareVersionPrefix, file...)
+	if err != nil && !errors.As(err, &utils.KeyNotFoundErr{}) {
 		return nil, err
 	}
 
@@ -229,7 +235,7 @@ func (a *Artifact) OSReleaseVariables(registryAndOrg, githubRepo, bugURL, homeUR
 		"KAIROS_FLAVOR_RELEASE":   a.FlavorRelease,
 		"KAIROS_VARIANT":          a.Variant,
 		"KAIROS_MODEL":            a.Model,
-		"KAIROS_ARCH":             a.Arch,
+		"KAIROS_TARGETARCH":       a.Arch,
 		"KAIROS_RELEASE":          a.Version,
 		"KAIROS_REGISTRY_AND_ORG": registryAndOrg,
 	}


### PR DESCRIPTION
and change ARCH to TARGETARCH to simplify how it's passed down from Earthly in the kairos repo

Part of: https://github.com/kairos-io/kairos/issues/1999