### PR TITLE
Don't require "Variant" to be set when generating base container names

### DIFF
--- a/versioneer/base_name_test.go
+++ b/versioneer/base_name_test.go
@@ -24,6 +24,20 @@ var _ = Describe("BaseContainerName", func() {
 		}
 	})
 
+	When("no variant is passed", func() {
+		var id, registryAndOrg string
+		BeforeEach(func() {
+			id = "master"
+			registryAndOrg = "quay.io/kairos"
+			artifact.Variant = ""
+		})
+
+		It("is valid", func() {
+			_, err := artifact.BaseContainerName(registryAndOrg, id)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	When("artifact is valid", func() {
 		var id, registryAndOrg string
 		BeforeEach(func() {

--- a/versioneer/versioneer.go
+++ b/versioneer/versioneer.go
@@ -91,11 +91,16 @@ func NewArtifactFromOSRelease(file ...string) (*Artifact, error) {
 }
 
 func (a *Artifact) Validate() error {
-	if a.FlavorRelease == "" {
-		return errors.New("FlavorRelease is empty")
-	}
 	if a.Variant == "" {
 		return errors.New("Variant is empty")
+	}
+
+	return a.ValidateBase()
+}
+
+func (a *Artifact) ValidateBase() error {
+	if a.FlavorRelease == "" {
+		return errors.New("FlavorRelease is empty")
 	}
 	if a.Model == "" {
 		return errors.New("Model is empty")
@@ -158,7 +163,7 @@ func (a *Artifact) BaseContainerName(registryAndOrg, id string) (string, error) 
 }
 
 func (a *Artifact) BaseTag() (string, error) {
-	if err := a.Validate(); err != nil {
+	if err := a.ValidateBase(); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
Part of: https://github.com/kairos-io/kairos/issues/2104

(Needs to be bumped in kairos-agent to complete the story)