### PR TITLE
[WIP] Switch version comparison to be a 2 step process

### DIFF
--- a/versioneer/tag_list.go
+++ b/versioneer/tag_list.go
@@ -74,16 +74,19 @@ func (tl TagList) Images() TagList {
 // This method returns all versions, not only newer ones. Use NewerVersions to
 // fetch only versions, newer than the one of the Artifact.
 func (tl TagList) OtherVersions() TagList {
-	sVersionForTag := tl.Artifact.SoftwareVersionForTag()
+	// sVersionForTag := tl.Artifact.SoftwareVersionForTag()
 
 	newTags := []string{}
 	for _, t := range tl.Images().Tags {
 		versions := extractVersions(t, *tl.Artifact)
-		if len(versions) > 0 && versions[0] != tl.Artifact.Version {
-			if len(versions) > 1 && versions[1] != sVersionForTag {
-				continue
-			}
+		// if len(versions) > 0 && versions[0] != tl.Artifact.Version {
+		// 	if len(versions) > 1 && versions[1] != sVersionForTag {
+		// 		continue
+		// 	}
 
+		// 	newTags = append(newTags, t)
+		// }
+		if len(versions) > 0 {
 			newTags = append(newTags, t)
 		}
 	}
@@ -218,8 +221,20 @@ func (tl TagList) newerVersions() TagList {
 	newTags := []string{}
 	for _, t := range tl.Tags {
 		versions := extractVersions(t, *tl.Artifact)
-		if len(versions) > 0 && semver.Compare(versions[0], tl.Artifact.VersionForTag()) == +1 {
+		if len(versions) == 0 {
+			continue
+		}
+
+		resComp := semver.Compare(versions[0], tl.Artifact.VersionForTag())
+
+		if resComp == +1 {
 			newTags = append(newTags, t)
+		}
+
+		if resComp == 0 {
+			if semver.Compare(versions[1], tl.Artifact.SoftwareVersionForTag()) == +1 {
+				newTags = append(newTags, t)
+			}
 		}
 	}
 

--- a/versioneer/tag_list_test.go
+++ b/versioneer/tag_list_test.go
@@ -158,6 +158,30 @@ var _ = Describe("TagList", func() {
 		})
 	})
 
+	Describe("NewerVersions despite newer SoftwareVersion", func() {
+		BeforeEach(func() {
+			tagList.Artifact = &versioneer.Artifact{
+				Flavor:                "opensuse",
+				FlavorRelease:         "leap-15.5",
+				Variant:               "standard",
+				Model:                 "generic",
+				Arch:                  "amd64",
+				Version:               "v2.4.2-rc2",
+				SoftwareVersion:       "v1.29.0+k3s1",
+				SoftwareVersionPrefix: "k3s",
+			}
+		})
+
+		It("returns only tags with newer Version field (the rest similar)", func() {
+			tags := tagList.NewerVersions().Tags
+
+			Expect(tags).To(HaveExactElements(
+				"leap-15.5-standard-amd64-generic-v2.4.2-k3sv1.27.6-k3s1",
+				"leap-15.5-standard-amd64-generic-v2.4.2-k3sv1.26.9-k3s1",
+				"leap-15.5-standard-amd64-generic-v2.4.2-k3sv1.28.2-k3s1"))
+		})
+	})
+
 	Describe("OtherSoftwareVersions", func() {
 		BeforeEach(func() {
 			tagList.Artifact = &versioneer.Artifact{


### PR DESCRIPTION
The matching of tags, should allow you to bump between k3s versions, this is because there will be cases where the user will have a k3s version which goes out of support, so they will be forced to pick a new one. For example:

current version: v2.4.2 with k3s 1.26.3

Available options:

v2.4.3 with k3s 1.27, 1.28 and 1.29

The 3 of them should be available for upgrade, specially because 1.26 is not an alternative