### PR TITLE
Check role of efi conf with prefix

### DIFF
--- a/state/state.go
+++ b/state/state.go
@@ -154,12 +154,16 @@ func getUKIBootState(logger zerolog.Logger) Boot {
 
 	logger.Debug().Msg("Current entry: " + currentEntry)
 
+	if !strings.HasSuffix(currentEntry, ".conf") {
+		return Unknown
+	}
+
 	switch {
-	case strings.HasSuffix(currentEntry, "active.conf"):
+	case strings.HasPrefix(currentEntry, "active"):
 		return Active
-	case strings.HasSuffix(currentEntry, "passive.conf"):
+	case strings.HasPrefix(currentEntry, "passive"):
 		return Passive
-	case strings.HasSuffix(currentEntry, "recovery.conf"):
+	case strings.HasPrefix(currentEntry, "recovery"):
 		return Recovery
 	default:
 		return Unknown


### PR DESCRIPTION
The names of the files are e.g.

```
kairos@edge-6073088171754c739beb690ca74a17a1:~$ ls /efi/loader/entries/
active.conf
active_stylus.registration_install-mode.conf
passive.conf
passive_stylus.registration_install-mode.conf
recovery.conf
recovery_stylus.registration_install-mode.conf
```

Since we are currently checking with a suffix e.g. `active.conf` then we don't make a match:

```
2024-02-29T18:28:59Z DBG Detected uki boot
2024-02-29T18:28:59Z DBG Current entry: active_stylus.registration_install-mode.conf
2024-02-29T18:28:59Z DBG Bootstate: unknown
2024-02-29T18:28:59Z DBG The BootState was BootState=unknown
2024-02-29T18:28:59Z INF Setting sentinel file to=unknown
2024-02-29T18:28:59Z INF Setting sentinel file to=uki_boot_mode
```
Using a prefix should fix the issue