### PR TITLE
Fix parsing cmdline when keys have a dash

### DIFF
--- a/machine/bootcmdline_test.go
+++ b/machine/bootcmdline_test.go
@@ -24,16 +24,16 @@ var _ = Describe("BootCMDLine", func() {
 
 			Expect(string(b)).To(Equal("baz:\n    bar: \"\"\nconfig_url: foo bar\n"), string(b))
 		})
-		It("fails if cmdline contains a dash", func() {
+		It("works if cmdline contains a dash or underscore", func() {
 			f, err := os.CreateTemp("", "test")
 			Expect(err).ToNot(HaveOccurred())
 			defer os.RemoveAll(f.Name())
 
-			err = os.WriteFile(f.Name(), []byte(`config-url="foo bar" baz.bar=""`), os.ModePerm)
+			err = os.WriteFile(f.Name(), []byte(`config-url="foo bar" ba_z.bar=""`), os.ModePerm)
 			Expect(err).ToNot(HaveOccurred())
 
 			_, err = DotToYAML(f.Name())
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/machine/bootcmdline_test.go
+++ b/machine/bootcmdline_test.go
@@ -24,5 +24,16 @@ var _ = Describe("BootCMDLine", func() {
 
 			Expect(string(b)).To(Equal("baz:\n    bar: \"\"\nconfig_url: foo bar\n"), string(b))
 		})
+		It("fails if cmdline contains a dash", func() {
+			f, err := os.CreateTemp("", "test")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(f.Name())
+
+			err = os.WriteFile(f.Name(), []byte(`config-url="foo bar" baz.bar=""`), os.ModePerm)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = DotToYAML(f.Name())
+			Expect(err).To(HaveOccurred())
+		})
 	})
 })


### PR DESCRIPTION
If a key has a dash we need to add quotes to it before parsing it with gojq, otherwise it will fail AND the full cmdline will not be parsed!

Fixes: https://github.com/kairos-io/kairos/issues/2343