### PR TITLE
Return empty query instead of null

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -476,12 +476,12 @@ func (c Config) Query(s string) (res string, err error) {
 	if err := json.Unmarshal(b, &dat); err != nil {
 		panic(err)
 	}
-
-	query, err := gojq.Parse(s)
+	// Adding "// empty" to the query so the output does not include a "null" if the value is empty
+	// This is not a json parse feature but a string one, so we should return normal values not json specific ones
+	query, err := gojq.Parse(s + "// empty")
 	if err != nil {
 		return res, err
 	}
-
 	iter := query.Run(dat) // or query.RunWithContext
 	for {
 		v, ok := iter.Next()


### PR DESCRIPTION
When a query has an empty value, we were returning null as the query results, but that its only a json value, specific to json. If the query returns nothing, we should return nothing.


```
root@localhost:~# /tmp/main config get "longhorn.values // empty" 
root@localhost:~# /tmp/main config get "longhorn.values" 
null
root@localhost:~# /tmp/main config get "longhorn.values // empty |@json" 
root@localhost:~# /tmp/main config get "longhorn.values |@json" 
"null"
```

Fixes: https://github.com/kairos-io/kairos/issues/2438