### PR TITLE
:bug:  added check for slice containing items before first item type is checked

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -109,6 +109,10 @@ func (c *Config) MergeConfig(newConfig *Config) error {
 }
 
 func mergeSlices(sliceA, sliceB []interface{}) ([]interface{}, error) {
+	// return sliceB if sliceA is empty
+	if len(sliceA) == 0 {
+		return sliceB, nil
+	}
 	// We use the first item in the slice to determine if there are maps present.
 	firstItem := sliceA[0]
 	// If the first item is a map, we concatenate both slices

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -302,6 +302,17 @@ info:
 			})
 		})
 
+		Context("empty slice", func() {
+			a := []interface{}{}
+			b := []interface{}{"two", 4}
+
+			It("merges", func() {
+				c, err := DeepMerge(a, b)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c).To(Equal([]interface{}{"two", 4}))
+			})
+		})
+
 		Context("slices containing maps", func() {
 			a := []interface{}{
 				map[string]interface{}{


### PR DESCRIPTION
Adds a length check of the slice before trying to check it's first item. returning second-slice immediately if the first is empty



Fixes: https://github.com/kairos-io/kairos/issues/2513