### PR TITLE
Avoid adding an extra line to os-release output

### DIFF
--- a/versioneer/cli.go
+++ b/versioneer/cli.go
@@ -186,7 +186,9 @@ func CliCommands() []*cli.Command {
 				if err != nil {
 					return err
 				}
-				fmt.Println(result)
+				// Do a normal print as we are already adding a \n at the end in the OSReleaseVariables function
+				// to avoid getting 1 empty line
+				fmt.Print(result)
 
 				return nil
 			},


### PR DESCRIPTION
some weird code around does not check for empty lines before processing and splitting the current line so it can lead to failures.

Just avoid printing an extra line with the output as when we generate the final result string we are already adding a \n at the end of each line which should be enough

Fixes: https://github.com/kairos-io/kairos/issues/2526