### PR TITLE
:bug: added case for nulling out existing objects with tests

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -178,6 +178,16 @@ func DeepMerge(a, b interface{}) (interface{}, error) {
 	typeA := reflect.TypeOf(a)
 	typeB := reflect.TypeOf(b)
 
+	// if b is null value, return null-value of whatever a currently is
+	if b == nil {
+		if typeA.Kind() == reflect.Slice {
+			return reflect.MakeSlice(typeA, 0, 0).Interface(), nil
+		} else if typeA.Kind() == reflect.Map {
+			return reflect.MakeMap(typeA).Interface(), nil
+		}
+		return reflect.Zero(typeA).Interface(), nil
+	}
+
 	// We don't support merging different data structures
 	if typeA.Kind() != typeB.Kind() {
 		return map[string]interface{}{}, fmt.Errorf("cannot merge %s with %s", typeA.String(), typeB.String())

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -103,6 +103,25 @@ info:
 				})
 			})
 		})
+		Context("reset keys", func() {
+			Context("remove keys", func() {
+				BeforeEach(func() {
+					err := yaml.Unmarshal([]byte("#cloud-config\nlist:\n - 1\n - 2\nname: Mario"), originalConfig)
+					Expect(err).ToNot(HaveOccurred())
+					err = yaml.Unmarshal([]byte("#cloud-config\nlist: null\nname: null"), newConfig)
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("overwrites", func() {
+					Expect(originalConfig.MergeConfig(newConfig)).ToNot(HaveOccurred())
+					Expect((*originalConfig)["list"]).To(BeEmpty())
+					name, isString := (*originalConfig)["name"].(string)
+					Expect(isString).To(BeTrue())
+					Expect(name).To(Equal(""))
+					Expect(*originalConfig).To(HaveLen(2))
+				})
+			})
+		})
 	})
 
 	Describe("MergeConfigURL", func() {
@@ -401,6 +420,32 @@ info:
 					"en": "one",
 					"es": "uno",
 					"nl": "één",
+				}))
+			})
+		})
+
+		Context("reset key", func() {
+			a := map[string]interface{}{
+				"string": "val",
+				"slice":  []interface{}{"valA", "valB"},
+				"map": map[string]interface{}{
+					"valA": "",
+					"valB": "",
+				},
+			}
+			b := map[string]interface{}{
+				"string": nil,
+				"slice":  nil,
+				"map":    nil,
+			}
+
+			It("merges", func() {
+				c, err := DeepMerge(a, b)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(c).To(Equal(map[string]interface{}{
+					"string": "",
+					"slice":  []interface{}{},
+					"map":    map[string]interface{}{},
 				}))
 			})
 		})


### PR DESCRIPTION
Checks if second item provided to merge is null, and returns an empty item if this is the case

Fixes: https://github.com/kairos-io/kairos/issues/2735