### PR TITLE
Ignore `-uki` suffixed artifacts in versioneer

### DIFF
--- a/versioneer/tag_list.go
+++ b/versioneer/tag_list.go
@@ -10,6 +10,8 @@ import (
 	"golang.org/x/mod/semver"
 )
 
+var ignoredImageSuffixes = []string{"-uki", "-img"}
+
 type TagList struct {
 	Tags           []string
 	Artifact       *Artifact
@@ -61,9 +63,7 @@ func (tl TagList) Images() TagList {
 	for _, t := range tl.Tags {
 		// Golang regexp doesn't support negative lookaheads so we filter some images
 		// outside regexp. Here we filter out `-img` and `-uki` artifacts.
-		if regexpObject.MatchString(t) &&
-			!strings.HasSuffix(t, "-img") &&
-			!strings.HasSuffix(t, "-uki") {
+		if regexpObject.MatchString(t) && !ignoreSuffixedTag(t) {
 			newTags = append(newTags, t)
 		}
 	}
@@ -356,4 +356,13 @@ func extractVersions(tagToCheck string, artifact Artifact) []string {
 // and RegistryAndOrg fields but with the given tags as Tags.
 func newTagListWithTags(tl TagList, tags []string) TagList {
 	return TagList{Artifact: tl.Artifact, RegistryAndOrg: tl.RegistryAndOrg, Tags: tags}
+}
+
+func ignoreSuffixedTag(tag string) bool {
+	for _, i := range ignoredImageSuffixes {
+		if strings.HasSuffix(tag, i) {
+			return true
+		}
+	}
+	return false
 }

--- a/versioneer/tag_list.go
+++ b/versioneer/tag_list.go
@@ -62,7 +62,7 @@ func (tl TagList) Images() TagList {
 	newTags := []string{}
 	for _, t := range tl.Tags {
 		// Golang regexp doesn't support negative lookaheads so we filter some images
-		// outside regexp. Here we filter out `-img` and `-uki` artifacts.
+		// outside regexp.
 		if regexpObject.MatchString(t) && !ignoreSuffixedTag(t) {
 			newTags = append(newTags, t)
 		}

--- a/versioneer/tag_list.go
+++ b/versioneer/tag_list.go
@@ -59,8 +59,11 @@ func (tl TagList) Images() TagList {
 
 	newTags := []string{}
 	for _, t := range tl.Tags {
-		// We have to filter "-img" tags outside the regexp because golang regexp doesn't support negative lookaheads.
-		if regexpObject.MatchString(t) && !strings.HasSuffix(t, "-img") {
+		// Golang regexp doesn't support negative lookaheads so we filter some images
+		// outside regexp. Here we filter out `-img` and `-uki` artifacts.
+		if regexpObject.MatchString(t) &&
+			!strings.HasSuffix(t, "-img") &&
+			!strings.HasSuffix(t, "-uki") {
 			newTags = append(newTags, t)
 		}
 	}

--- a/versioneer/tag_list_test.go
+++ b/versioneer/tag_list_test.go
@@ -40,6 +40,20 @@ var _ = Describe("TagList", func() {
 
 			expectOnlyImages(images.Tags)
 		})
+
+		// Fixed bug
+		It("filters out -uki suffixed images", func() {
+			// Add a -uki suffixed (otherwise matching) artifact
+			badTag := "tumbleweed-standard-amd64-generic-v2.4.2-k3sv1.27.6-k3s1-uki"
+			tagList.Tags = append(tagList.Tags, badTag)
+			images := tagList.Images()
+
+			Expect(images.Tags).ToNot(ContainElement(badTag))
+			// Sanity check, that we didn't filter everything out
+			Expect(len(images.Tags)).To(BeNumerically(">", 4))
+
+			expectOnlyImages(images.Tags)
+		})
 	})
 
 	Describe("FullImages", func() {
@@ -356,6 +370,7 @@ func expectOnlyImages(images []string) {
 	Expect(images).ToNot(ContainElement(ContainSubstring(".sbom")))
 	Expect(images).ToNot(ContainElement(ContainSubstring(".sig")))
 	Expect(images).ToNot(ContainElement(ContainSubstring("-img")))
+	Expect(images).ToNot(ContainElement(ContainSubstring("-uki")))
 
 	Expect(images).To(HaveEach(MatchRegexp((".*-(core|standard)-(amd64|arm64)-.*-v.*"))))
 }


### PR DESCRIPTION
Part of: https://github.com/kairos-io/kairos/issues/2710


This is a different approach to this: https://github.com/kairos-io/kairos-sdk/pull/255/files

Here we just ignore the `-uki` suffixed artifacts and we are going to print a message in kairos-agent when uki mode is used.