### PR TITLE
Override the ghw paths on ghw mock

### DIFF
--- a/ghw/mocks/ghw_mock.go
+++ b/ghw/mocks/ghw_mock.go
@@ -48,6 +48,8 @@ func (g *GhwMock) CreateDevices() {
 	d, _ := os.MkdirTemp("", "ghwmock")
 	g.Chroot = d
 	g.paths = ghw.NewPaths(d)
+	// Set the env override to the chroot
+	_ = os.Setenv("GHW_CHROOT", d)
 	// Create the /sys/block dir
 	_ = os.MkdirAll(g.paths.SysBlock, 0755)
 	// Create the /run/udev/data dir
@@ -157,5 +159,7 @@ func (g *GhwMock) RemovePartitionFromDisk(diskName string, partitionName string)
 
 // Clean will remove the chroot dir and unset the env var
 func (g *GhwMock) Clean() {
+	// Uset the test override
+	_ = os.Unsetenv("GHW_CHROOT")
 	_ = os.RemoveAll(g.Chroot)
 }

--- a/go.sum
+++ b/go.sum
@@ -359,6 +359,7 @@ github.com/saferwall/pe v1.5.4 h1:tLmMggEMUfeqrpJ25zS/okUQmyFdD5xWKL2+z9njCqg=
 github.com/saferwall/pe v1.5.4/go.mod h1:mJx+PuptmNpoPFBNhWs/uDMFL/kTHVZIkg0d4OUJFbQ=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/secDre4mer/pkcs7 v0.0.0-20240322103146-665324a4461d h1:RQqyEogx5J6wPdoxqL132b100j8KjcVHO1c0KLRoIhc=
 github.com/secDre4mer/pkcs7 v0.0.0-20240322103146-665324a4461d/go.mod h1:PegD7EVqlN88z7TpCqH92hHP+GBpfomGCCnw1PFtNOA=
 github.com/sergi/go-diff v1.2.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=

--- a/types/partitions.go
+++ b/types/partitions.go
@@ -6,10 +6,10 @@ type Partition struct {
 	Size            uint     `yaml:"size,omitempty" mapstructure:"size"`
 	FS              string   `yaml:"fs,omitempty" mapstrcuture:"fs"`
 	Flags           []string `yaml:"flags,omitempty" mapstrcuture:"flags"`
-	UUID            string
-	MountPoint      string `yaml:"-"`
-	Path            string `yaml:"-"`
-	Disk            string `yaml:"-"`
+	UUID            string   `yaml:"uuid,omitempty" mapstructure:"uuid"`
+	MountPoint      string   `yaml:"-"`
+	Path            string   `yaml:"-"`
+	Disk            string   `yaml:"-"`
 }
 
 type PartitionList []*Partition


### PR DESCRIPTION
When mocking the ghw stuff, we need to set the proper env var so the normal ghw scan looks at our mocked path instead.

On clean, we unset the var

This is so when using the mock, the ghw clone will pick up the env var and automatically set the paths pointing to it. This is useful for testing and was present on ghw as well, but now we can directly use it on our mock object so its done for us automatically