### PR TITLE
Support the use of private registry with Luet

### DIFF
--- a/bundles/bundles.go
+++ b/bundles/bundles.go
@@ -284,11 +284,13 @@ func (l *LuetInstaller) Install(config *BundleConfig) error {
 	}
 	out, err := utils.SH(
 		fmt.Sprintf(
-			`LUET_CONFIG_FROM_HOST=false luet repo add --system-dbpath %s --system-target %s kairos-system -y --description "Automatically generated kairos-system" --url "%s" --type "%s"`,
+			`LUET_CONFIG_FROM_HOST=false luet repo add --system-dbpath %s --system-target %s kairos-system -y --description "Automatically generated kairos-system" --url "%s" --type "%s" --username "%s" --passwd "%s"`,
 			config.DBPath,
 			config.RootPath,
 			repo,
 			t,
+			config.Auth.Username,
+			config.Auth.Password,
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
Considering that there is no docker authentication file during installation and first boot, it is necessary to access the package repository through the authentication information configured in cloudconfig.