### PR TITLE
Be able to build the logger on windows

### DIFF
--- a/types/logger_linux.go
+++ b/types/logger_linux.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package types
+
+import (
+	"io"
+	"net"
+
+	"github.com/rs/zerolog/journald"
+)
+
+func isJournaldAvailable() bool {
+	conn, err := net.Dial("unixgram", "/run/systemd/journal/socket")
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+	return true
+}
+
+func getJournaldWriter() io.Writer {
+	return journald.NewJournalDWriter()
+}

--- a/types/logger_windows.go
+++ b/types/logger_windows.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package types
+
+import "io"
+
+func isJournaldAvailable() bool {
+	return false
+}
+
+func getJournaldWriter() io.Writer {
+	return nil // No journald on Windows
+}


### PR DESCRIPTION
Seems like provider can build for windows for the kairosctl command and it would fail due to the systemd libs not being available to build under windows so we need to protect against that