### PR TITLE
Track logger fds and provide a close method

### DIFF
--- a/kcrypt/bus/bus.go
+++ b/kcrypt/bus/bus.go
@@ -55,6 +55,7 @@ func (b *Bus) Initialize() {
 	}
 
 	log := types.NewKairosLogger("kcrypt", level, false)
+	defer log.Close()
 
 	b.LoadProviders()
 	for i := range b.Events {


### PR DESCRIPTION
So consumers can just close them

required for things that migth mount/remount paths and such and cant keep files open in there