### PR TITLE
fix: enable quiet logging in GetDisks function

### DIFF
--- a/ghw/ghw.go
+++ b/ghw/ghw.go
@@ -85,7 +85,7 @@ func isMultipathDevice(paths *Paths, entry os.DirEntry, logger *types.KairosLogg
 
 func GetDisks(paths *Paths, logger *types.KairosLogger) []*types.Disk {
 	if logger == nil {
-		newLogger := types.NewKairosLogger("ghw", "info", false)
+		newLogger := types.NewKairosLogger("ghw", "info", true)
 		logger = &newLogger
 	}
 	disks := make([]*types.Disk, 0)


### PR DESCRIPTION
Updated the logger initialization in the GetDisks function to enable quiet logging when a new logger is created. This avoids polluting the stdout when no logger is passed to the function

Fixes: https://github.com/kairos-io/kairos/issues/3605