### PR TITLE
cryptsetup v2.8 does not allow slashes

### DIFF
--- a/kcrypt/lock.go
+++ b/kcrypt/lock.go
@@ -221,6 +221,8 @@ func formatLuks(device, name, mapper, label, pass string, logger types.KairosLog
 
 	// Refresh needs the password as its doing actions on the device directly
 	l.Debug().Msg("discards")
+	// Note: cryptsetup v2.8+ expects the device name (not the device path) for the 'refresh' command.
+	// Using 'name' with v2.7 also works, hence why no fallback is needed for backward compatibility.
 	cmd := exec.Command("cryptsetup", "refresh", "--persistent", "--allow-discards", name)
 	cmd.Stdin = strings.NewReader(pass)
 	output, err := cmd.CombinedOutput()

--- a/kcrypt/lock.go
+++ b/kcrypt/lock.go
@@ -221,7 +221,7 @@ func formatLuks(device, name, mapper, label, pass string, logger types.KairosLog
 
 	// Refresh needs the password as its doing actions on the device directly
 	l.Debug().Msg("discards")
-	cmd := exec.Command("cryptsetup", "refresh", "--persistent", "--allow-discards", mapper)
+	cmd := exec.Command("cryptsetup", "refresh", "--persistent", "--allow-discards", name)
 	cmd.Stdin = strings.NewReader(pass)
 	output, err := cmd.CombinedOutput()
 


### PR DESCRIPTION
This fixes the following error during installation of a 25.10 system, which comes with cryptsetup v2.8 instead of the v2.7 that we've used so far. The new version is stricter and only accepts a name, not a path, and for what I can see the older version accepts also a name, hence why I didn't add a fallback, but I'm not acquainted enough with cryptsetup to be sure

```
2025-09-12T14:24:22Z ERR format luks error="refresh err: exit status 1, out: Name must not contain '/' character.\n"
2025-09-12T14:24:22Z ERR could not encrypt partition: refresh err: exit status 1, out: Name must not contain '/' character.

2025-09-12T14:24:22Z ERR could not encrypt partitions error="refresh err: exit status 1, out: Name must not contain '/' character.\n"
2025-09-12T14:24:22Z ERR running uki encryption hooks: refresh err: exit status 1, out: Name must not contain '/' character.

2025-09-12T14:24:22Z INF Unmounting disk partitions
1 error occurred:
        * refresh err: exit status 1, out: Name must not contain '/' character.
```

I also see there are other commands like `cryptsetup close /dev/disk/by-label/%s` but I'm not sure if those will also break, maybe we can just merge and keep running the different tests on Ubuntu 25.10 to catch these.