### PR TITLE
Add riscv64 platform support

### DIFF
--- a/types/platform/platform.go
+++ b/types/platform/platform.go
@@ -28,6 +28,7 @@ const (
 	ArchAmd64 = "amd64"
 	Archx86   = "x86_64"
 	ArchArm64 = "arm64"
+	ArchRiscv = "riscv64"
 )
 
 type Platform struct {
@@ -119,6 +120,8 @@ func archToGolangArch(arch string) (string, error) {
 		return ArchAmd64, nil
 	case ArchArm64:
 		return ArchArm64, nil
+	case ArchRiscv:
+		return ArchRiscv, nil
 	default:
 		return "", errInvalidArch
 	}
@@ -132,6 +135,8 @@ func golangArchToArch(arch string) (string, error) {
 		return Archx86, nil
 	case ArchArm64:
 		return ArchArm64, nil
+	case ArchRiscv:
+		return ArchRiscv, nil
 	default:
 		return "", errInvalidArch
 	}

--- a/types/platform/platform_test.go
+++ b/types/platform/platform_test.go
@@ -17,6 +17,13 @@ var _ = Describe("Types", Label("types", "common"), func() {
 			Expect(platform.OS).To(Equal("linux"))
 			Expect(platform.Arch).To(Equal(sdkPlatform.ArchArm64))
 			Expect(platform.GolangArch).To(Equal(sdkPlatform.ArchArm64))
+
+			platform, err = sdkPlatform.NewPlatform("linux", sdkPlatform.ArchRiscv)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(platform.OS).To(Equal("linux"))
+			Expect(platform.Arch).To(Equal(sdkPlatform.ArchRiscv))
+			Expect(platform.GolangArch).To(Equal(sdkPlatform.ArchRiscv))
+
 			platform, err = sdkPlatform.NewPlatform("linux", sdkPlatform.Archx86)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(platform.OS).To(Equal("linux"))
@@ -45,6 +52,11 @@ var _ = Describe("Types", Label("types", "common"), func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(platform.Arch).To(Equal(sdkPlatform.ArchArm64))
 			Expect(platform.GolangArch).To(Equal(sdkPlatform.ArchArm64))
+
+			platform, err = sdkPlatform.NewPlatformFromArch(sdkPlatform.ArchRiscv)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(platform.Arch).To(Equal(sdkPlatform.ArchRiscv))
+			Expect(platform.GolangArch).To(Equal(sdkPlatform.ArchRiscv))
 
 			platform, err = sdkPlatform.NewPlatformFromArch(sdkPlatform.Archx86)
 			Expect(err).ToNot(HaveOccurred())

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -332,9 +332,31 @@ func GetEfiGrubFiles(arch string) []string {
 		modNames = append(modNames, "/usr/lib/grub/arm64-efi/grubaa64.efi")               // hadron
 
 	case "riscv64":
-		modNames = append(modNames, "/usr/lib/grub/riscv64-efi/grubriscv64.efi")            // debian-style EFI install
-		modNames = append(modNames, "/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi") // ubuntu
-		modNames = append(modNames, "/boot/efi/EFI/BOOT/BOOTRISCV64.EFI")                   // removable media fallback
+		// Verified Debian 13 modules path:
+		// https://packages.debian.org/trixie/riscv64/grub-efi-riscv64-bin/filelist
+		modNames = append(modNames, "/usr/lib/grub/riscv64-efi/grubriscv64.efi")
+		// Ubuntu Noble ships grub-efi-riscv64 / grub-efi-riscv64-bin for riscv64, and
+		// Debian-family layouts commonly use the monolithic output here. Ubuntu file list
+		// was not directly available during implementation, so treat this as a Debian-style
+		// derivative path to validate against images:
+		// https://packages.ubuntu.com/noble/admin/grub-efi
+		modNames = append(modNames, "/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi")
+		// Verified Debian-family ESP path for Debian 13 systems:
+		// https://wiki.debian.org/InstallingDebianOn/StarFive/VisionFiveV2
+		modNames = append(modNames, "/boot/efi/EFI/debian/grubriscv64.efi")
+		// Ubuntu Noble likely follows the same ESP filename convention under /EFI/ubuntu/.
+		// Keep this separate from the Debian path because external consumers test Ubuntu
+		// images directly:
+		// https://packages.ubuntu.com/noble/admin/grub-efi
+		// https://bugs.launchpad.net/bugs/2104572
+		modNames = append(modNames, "/boot/efi/EFI/ubuntu/grubriscv64.efi")
+		// Verified Fedora 42 ESP path:
+		// https://riscv-koji.fedoraproject.org/koji/rpminfo?rpmID=25558
+		modNames = append(modNames, "/boot/efi/EFI/fedora/grubriscv64.efi")
+		// Verified removable-media fallback name used by Debian-family riscv64 installs:
+		// https://wiki.debian.org/UEFI
+		// https://wiki.debian.org/InstallingDebianOn/StarFive/VisionFiveV2
+		modNames = append(modNames, "/boot/efi/EFI/BOOT/BOOTRISCV64.EFI")
 
 	default:
 		modNames = append(modNames, "/usr/share/efi/x86_64/grub.efi")                     // suse

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -331,6 +331,11 @@ func GetEfiGrubFiles(arch string) []string {
 		modNames = append(modNames, "/boot/efi/EFI/almalinux/grubaa64.efi")               // almalinux
 		modNames = append(modNames, "/usr/lib/grub/arm64-efi/grubaa64.efi")               // hadron
 
+	case "riscv64":
+		modNames = append(modNames, "/usr/lib/grub/riscv64-efi/grubriscv64.efi")            // debian-style EFI install
+		modNames = append(modNames, "/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi") // ubuntu
+		modNames = append(modNames, "/boot/efi/EFI/BOOT/BOOTRISCV64.EFI")                   // removable media fallback
+
 	default:
 		modNames = append(modNames, "/usr/share/efi/x86_64/grub.efi")                     // suse
 		modNames = append(modNames, "/usr/lib/grub/x86_64-efi-signed/grubx64.efi.signed") // ubuntu + debian
@@ -358,6 +363,8 @@ func GetEfiShimFiles(arch string) []string {
 		modNames = append(modNames, "/boot/efi/EFI/redhat/shim.efi")            // redhat
 		modNames = append(modNames, "/boot/efi/EFI/redhat/shimaa64.efi")        // redhat
 		modNames = append(modNames, "/boot/efi/EFI/almalinux/shim.efi")         // almalinux
+	case "riscv64":
+		// No stable shim file conventions are handled here for riscv64 yet.
 	default:
 		modNames = append(modNames, "/usr/share/efi/x86_64/shim.efi")          // suse + Hadron
 		modNames = append(modNames, "/usr/lib/shim/shimx64.efi.dualsigned")    // ubuntu

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import "testing"
+
+func TestGetEfiGrubFiles(t *testing.T) {
+	tests := []struct {
+		arch     string
+		expected string
+	}{
+		{
+			arch:     "amd64",
+			expected: "/usr/share/efi/x86_64/grub.efi",
+		},
+		{
+			arch:     "arm64",
+			expected: "/usr/share/efi/aarch64/grub.efi",
+		},
+		{
+			arch:     "riscv64",
+			expected: "/usr/lib/grub/riscv64-efi/grubriscv64.efi",
+		},
+	}
+
+	for _, tt := range tests {
+		files := GetEfiGrubFiles(tt.arch)
+		if len(files) == 0 {
+			t.Fatalf("GetEfiGrubFiles(%q) returned no files", tt.arch)
+		}
+
+		found := false
+		for _, file := range files {
+			if file == tt.expected {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("GetEfiGrubFiles(%q) did not include %q; got %v", tt.arch, tt.expected, files)
+		}
+	}
+}
+
+func TestGetEfiShimFiles(t *testing.T) {
+	arm64Files := GetEfiShimFiles("arm64")
+	if len(arm64Files) == 0 {
+		t.Fatal("GetEfiShimFiles(\"arm64\") returned no files")
+	}
+
+	riscv64Files := GetEfiShimFiles("riscv64")
+	if len(riscv64Files) != 0 {
+		t.Fatalf("GetEfiShimFiles(\"riscv64\") = %v, want no shim paths", riscv64Files)
+	}
+}

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -5,19 +5,26 @@ import "testing"
 func TestGetEfiGrubFiles(t *testing.T) {
 	tests := []struct {
 		arch     string
-		expected string
+		expected []string
 	}{
 		{
 			arch:     "amd64",
-			expected: "/usr/share/efi/x86_64/grub.efi",
+			expected: []string{"/usr/share/efi/x86_64/grub.efi"},
 		},
 		{
 			arch:     "arm64",
-			expected: "/usr/share/efi/aarch64/grub.efi",
+			expected: []string{"/usr/share/efi/aarch64/grub.efi"},
 		},
 		{
-			arch:     "riscv64",
-			expected: "/usr/lib/grub/riscv64-efi/grubriscv64.efi",
+			arch: "riscv64",
+			expected: []string{
+				"/usr/lib/grub/riscv64-efi/grubriscv64.efi",
+				"/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi",
+				"/boot/efi/EFI/debian/grubriscv64.efi",
+				"/boot/efi/EFI/ubuntu/grubriscv64.efi",
+				"/boot/efi/EFI/fedora/grubriscv64.efi",
+				"/boot/efi/EFI/BOOT/BOOTRISCV64.EFI",
+			},
 		},
 	}
 
@@ -27,15 +34,17 @@ func TestGetEfiGrubFiles(t *testing.T) {
 			t.Fatalf("GetEfiGrubFiles(%q) returned no files", tt.arch)
 		}
 
-		found := false
-		for _, file := range files {
-			if file == tt.expected {
-				found = true
-				break
+		for _, expected := range tt.expected {
+			found := false
+			for _, file := range files {
+				if file == expected {
+					found = true
+					break
+				}
 			}
-		}
-		if !found {
-			t.Fatalf("GetEfiGrubFiles(%q) did not include %q; got %v", tt.arch, tt.expected, files)
+			if !found {
+				t.Fatalf("GetEfiGrubFiles(%q) did not include %q; got %v", tt.arch, expected, files)
+			}
 		}
 	}
 }

--- a/versioneer/tag_list.go
+++ b/versioneer/tag_list.go
@@ -56,7 +56,7 @@ func (tl TagList) Less(i, j int) bool {
 // - sig
 // - -img
 func (tl TagList) Images() TagList {
-	pattern := `.*-(core|standard)-(amd64|arm64)-.*-v.*`
+	pattern := `.*-(core|standard)-(amd64|arm64|riscv64)-.*-v.*`
 	regexpObject := regexp.MustCompile(pattern)
 
 	newTags := []string{}

--- a/versioneer/tag_list_test.go
+++ b/versioneer/tag_list_test.go
@@ -41,6 +41,15 @@ var _ = Describe("TagList", func() {
 			expectOnlyImages(images.Tags)
 		})
 
+		It("includes riscv64 image tags", func() {
+			goodTag := "tumbleweed-core-riscv64-generic-v2.4.2"
+			tagList.Tags = append(tagList.Tags, goodTag)
+
+			images := tagList.Images()
+
+			Expect(images.Tags).To(ContainElement(goodTag))
+		})
+
 		// Fixed bug
 		It("filters out -uki suffixed images", func() {
 			// Add a -uki suffixed (otherwise matching) artifact
@@ -372,5 +381,5 @@ func expectOnlyImages(images []string) {
 	Expect(images).ToNot(ContainElement(ContainSubstring("-img")))
 	Expect(images).ToNot(ContainElement(ContainSubstring("-uki")))
 
-	Expect(images).To(HaveEach(MatchRegexp((".*-(core|standard)-(amd64|arm64)-.*-v.*"))))
+	Expect(images).To(HaveEach(MatchRegexp((".*-(core|standard)-(amd64|arm64|riscv64)-.*-v.*"))))
 }


### PR DESCRIPTION
## Summary
- add riscv64 to the platform arch constants and arch conversion helpers
- extend riscv64 support in EFI GRUB path detection for external consumers
- allow versioneer image tag filtering to recognize riscv64 images
- add tests covering the new riscv64 behavior

## Related
- part of kairos-io/kairos#4083

## Testing
- go test ./types/platform/...
- go test ./utils ./versioneer
