### PR TITLE
Port OCIImageExtractor from kairos-agent

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -324,8 +324,6 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jzelinskie/whirlpool v0.0.0-20201016144138-0675e54bb004 h1:G+9t9cEtnC9jFiTxyptEKuNIAbiN5ZCQzX2a74lj3xg=
 github.com/jzelinskie/whirlpool v0.0.0-20201016144138-0675e54bb004/go.mod h1:KmHnJWQrgEvbuy0vcvj00gtMqbvNn1L+3YUZLK/B92c=
-github.com/kairos-io/tpm-helpers v0.0.0-20251107132133-df566ad2d185 h1:XSUSjYFkIFdZhFEc3Z6xcqggbgPOclKz+9hntaA+q8o=
-github.com/kairos-io/tpm-helpers v0.0.0-20251107132133-df566ad2d185/go.mod h1:zOtMRZ4zGpy+qL6W1N0LrczM/9T0sdoaJ1K5PgfchAs=
 github.com/kairos-io/tpm-helpers v0.0.0-20260608091616-8a4ccb53d8f7 h1:xa+JqfOHMr6yenQKtVjnkeb6k/D1zwBa/35Mw/peRm0=
 github.com/kairos-io/tpm-helpers v0.0.0-20260608091616-8a4ccb53d8f7/go.mod h1:u68dFslI+rdr+NTwVWnyXpuPAGLlylhBgDycSVZ0h8E=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
@@ -585,8 +583,6 @@ golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
-golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
-golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/mod v0.37.0 h1:vF1DjpVEshcIqoEaauuHebaLk1O1forxjxBaVn884JQ=
 golang.org/x/mod v0.37.0/go.mod h1:m8S8VeM9r4dzDwjrKO0a1sZP3YjeMamRRlD+fmR2Q/0=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/utils/image/extractor.go
+++ b/utils/image/extractor.go
@@ -1,7 +1,6 @@
 package image
 
 import (
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	imagetypes "github.com/kairos-io/kairos-sdk/types/images"
 	"github.com/kairos-io/kairos-sdk/utils"
 )
@@ -25,15 +24,15 @@ func (e OCIImageExtractor) pullOptions() []GetOption {
 	return nil
 }
 
-// resolvePlatform keeps a valid explicit platform, otherwise falls back to the
-// current host platform.
+// resolvePlatform defaults to the current host platform only when no platform
+// was requested. An explicit platformRef is passed through untouched so GetImage
+// validates it and surfaces an error, rather than silently falling back to the
+// host platform and pulling the wrong image.
 func resolvePlatform(platformRef string) string {
-	if platformRef != "" {
-		if _, err := v1.ParsePlatform(platformRef); err == nil {
-			return platformRef
-		}
+	if platformRef == "" {
+		return utils.GetCurrentPlatform()
 	}
-	return utils.GetCurrentPlatform()
+	return platformRef
 }
 
 func (e OCIImageExtractor) ExtractImage(imageRef, destination, platformRef string, excludes ...string) error {

--- a/utils/image/extractor.go
+++ b/utils/image/extractor.go
@@ -1,0 +1,49 @@
+package image
+
+import (
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	imagetypes "github.com/kairos-io/kairos-sdk/types/images"
+	"github.com/kairos-io/kairos-sdk/utils"
+)
+
+// OCIImageExtractor is the default implementation of imagetypes.ImageExtractor:
+// it pulls an OCI image with GetImage and unpacks it with ExtractOCIImage.
+//
+// Set Insecure to allow pulling from registries served over plain HTTP or
+// presenting an untrusted/self-signed TLS certificate (see WithInsecureRegistry).
+type OCIImageExtractor struct {
+	Insecure bool
+}
+
+var _ imagetypes.ImageExtractor = OCIImageExtractor{}
+
+// pullOptions translates the extractor's configuration into GetImage options.
+func (e OCIImageExtractor) pullOptions() []GetOption {
+	if e.Insecure {
+		return []GetOption{WithInsecureRegistry()}
+	}
+	return nil
+}
+
+// resolvePlatform keeps a valid explicit platform, otherwise falls back to the
+// current host platform.
+func resolvePlatform(platformRef string) string {
+	if platformRef != "" {
+		if _, err := v1.ParsePlatform(platformRef); err == nil {
+			return platformRef
+		}
+	}
+	return utils.GetCurrentPlatform()
+}
+
+func (e OCIImageExtractor) ExtractImage(imageRef, destination, platformRef string, excludes ...string) error {
+	img, err := GetImage(imageRef, resolvePlatform(platformRef), nil, nil, e.pullOptions()...)
+	if err != nil {
+		return err
+	}
+	return ExtractOCIImage(img, destination, excludes...)
+}
+
+func (e OCIImageExtractor) GetOCIImageSize(imageRef, platformRef string) (int64, error) {
+	return GetOCIImageSize(imageRef, resolvePlatform(platformRef), nil, nil, e.pullOptions()...)
+}

--- a/utils/image/extractor_test.go
+++ b/utils/image/extractor_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -99,9 +100,11 @@ var _ = Describe("OCIImageExtractor", func() {
 			err := image.OCIImageExtractor{Insecure: true}.ExtractImage(imageRef, destDir, "linux/amd64")
 			Expect(err).ToNot(HaveOccurred())
 
-			entries, err := os.ReadDir(destDir)
+			// Assert the known file from currentUserImage was extracted verbatim,
+			// not merely that something landed in the directory.
+			content, err := os.ReadFile(filepath.Join(destDir, "hello.txt"))
 			Expect(err).ToNot(HaveOccurred())
-			Expect(entries).ToNot(BeEmpty())
+			Expect(string(content)).To(Equal("hello from the insecure registry"))
 		})
 
 		It("GetOCIImageSize requires Insecure for this registry", func() {

--- a/utils/image/extractor_test.go
+++ b/utils/image/extractor_test.go
@@ -1,0 +1,116 @@
+package image_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"io"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	ggcrregistry "github.com/google/go-containerregistry/pkg/registry"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/tarball"
+
+	"github.com/kairos-io/kairos-sdk/utils/image"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// currentUserImage builds a single-layer image whose one file is owned by the
+// current uid/gid, so ExtractOCIImage's chown succeeds when the suite runs
+// rootless (v1random.Image writes uid/gid 0, which a non-root lchown rejects).
+func currentUserImage() (v1.Image, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	content := []byte("hello from the insecure registry")
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     "hello.txt",
+		Typeflag: tar.TypeReg,
+		Mode:     0o644,
+		Size:     int64(len(content)),
+		Uid:      os.Getuid(),
+		Gid:      os.Getgid(),
+	}); err != nil {
+		return nil, err
+	}
+	if _, err := tw.Write(content); err != nil {
+		return nil, err
+	}
+	if err := tw.Close(); err != nil {
+		return nil, err
+	}
+	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return mutate.AppendLayers(empty.Image, layer)
+}
+
+var _ = Describe("OCIImageExtractor", func() {
+	Describe("against a registry with an untrusted (self-signed) TLS certificate", func() {
+		var (
+			server   *httptest.Server
+			imageRef string
+			destDir  string
+		)
+
+		BeforeEach(func() {
+			server = httptest.NewTLSServer(ggcrregistry.New())
+
+			u, err := url.Parse(server.URL)
+			Expect(err).ToNot(HaveOccurred())
+			imageRef = u.Host + "/test/extract:latest"
+
+			img, err := currentUserImage()
+			Expect(err).ToNot(HaveOccurred())
+			ref, err := name.ParseReference(imageRef, name.Insecure)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(remote.Write(ref, img, remote.WithTransport(insecureTransport()))).To(Succeed())
+
+			destDir, err = os.MkdirTemp("", "sdk-extractor-*")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			server.Close()
+			Expect(os.RemoveAll(destDir)).To(Succeed())
+		})
+
+		It("ExtractImage fails when Insecure is false", func() {
+			err := image.OCIImageExtractor{}.ExtractImage(imageRef, destDir, "linux/amd64")
+			Expect(err).To(HaveOccurred())
+			// Must fail on certificate verification, not because the image is missing.
+			Expect(strings.ToLower(err.Error())).To(Or(
+				ContainSubstring("certificate"),
+				ContainSubstring("tls"),
+				ContainSubstring("x509"),
+			))
+		})
+
+		It("ExtractImage succeeds and unpacks files when Insecure is true", func() {
+			err := image.OCIImageExtractor{Insecure: true}.ExtractImage(imageRef, destDir, "linux/amd64")
+			Expect(err).ToNot(HaveOccurred())
+
+			entries, err := os.ReadDir(destDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(entries).ToNot(BeEmpty())
+		})
+
+		It("GetOCIImageSize requires Insecure for this registry", func() {
+			_, err := image.OCIImageExtractor{}.GetOCIImageSize(imageRef, "linux/amd64")
+			Expect(err).To(HaveOccurred())
+
+			size, err := image.OCIImageExtractor{Insecure: true}.GetOCIImageSize(imageRef, "linux/amd64")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(size).To(BeNumerically(">", 0))
+		})
+	})
+})


### PR DESCRIPTION
so that it can be used by AuroraBoot and kairos-agent alike.

Part of https://github.com/kairos-io/kairos/issues/4081
