### PR TITLE
feat(agentrun): add package to drive kairos-agent manual-install

### DIFF
--- a/agentrun/agentrun.go
+++ b/agentrun/agentrun.go
@@ -1,0 +1,105 @@
+// Package agentrun drives kairos-agent's manual-install and parses its
+// JSON-Lines progress stream. It has no TUI dependencies so installer
+// frontends (and tests) can reuse it in isolation.
+//
+// It implements the installer side of the kairos-agent installer contract:
+// build a `kairos-agent manual-install` invocation, run it with progress
+// emission enabled, and turn the agent's JSON-Lines stdout into structured
+// progress events.
+package agentrun
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"os/exec"
+)
+
+// EnvAgentBin overrides agent discovery with an explicit path.
+const EnvAgentBin = "KAIROS_AGENT_BIN"
+
+// agentBinName is the fixed name looked up on PATH.
+const agentBinName = "kairos-agent"
+
+// ProgressEvent is one parsed JSON-Lines progress line from the agent.
+type ProgressEvent struct {
+	Event   string `json:"event"`
+	Step    string `json:"step"`
+	Message string `json:"message"`
+}
+
+// ResolveAgentBin returns the kairos-agent path: KAIROS_AGENT_BIN (must exist)
+// then kairos-agent on PATH, else "".
+func ResolveAgentBin() string {
+	if p := os.Getenv(EnvAgentBin); p != "" {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	if p, err := exec.LookPath(agentBinName); err == nil {
+		return p
+	}
+	return ""
+}
+
+// Command builds the manual-install invocation. finishAction is one of
+// "reboot", "poweroff", or anything else (no finish flag). It sets
+// KAIROS_AGENT_PROGRESS=1 so the agent emits progress events.
+func Command(agentBin, cfgPath, source, finishAction string) *exec.Cmd {
+	args := []string{"manual-install"}
+	if source != "" {
+		args = append(args, "--source", source)
+	}
+	args = append(args, "--use-default-dirs")
+	switch finishAction {
+	case "reboot":
+		args = append(args, "--reboot")
+	case "poweroff":
+		args = append(args, "--poweroff")
+	}
+	args = append(args, cfgPath)
+
+	cmd := exec.Command(agentBin, args...)
+	cmd.Env = append(os.Environ(), "KAIROS_AGENT_PROGRESS=1")
+	return cmd
+}
+
+// ParseLine parses one stdout line. ok is true only for a JSON object carrying
+// a non-empty "event" field; everything else (plain logs, eventless JSON) is
+// reported as ok=false.
+func ParseLine(line []byte) (ProgressEvent, bool) {
+	var ev ProgressEvent
+	if err := json.Unmarshal(line, &ev); err != nil {
+		return ProgressEvent{}, false
+	}
+	if ev.Event == "" {
+		return ProgressEvent{}, false
+	}
+	return ev, true
+}
+
+// Run execs the agent, calling onEvent for each progress event and onLog for
+// each non-event stdout line. It returns the process exit error, if any.
+func Run(agentBin, cfgPath, source, finishAction string, onEvent func(ProgressEvent), onLog func(string)) error {
+	cmd := Command(agentBin, cfgPath, source, finishAction)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if ev, ok := ParseLine(line); ok {
+			onEvent(ev)
+		} else if len(line) > 0 {
+			onLog(string(line))
+		}
+	}
+	return cmd.Wait()
+}

--- a/agentrun/agentrun_test.go
+++ b/agentrun/agentrun_test.go
@@ -1,0 +1,126 @@
+package agentrun_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kairos-io/kairos-sdk/agentrun"
+)
+
+var _ = Describe("agentrun", func() {
+	Describe("ResolveAgentBin", func() {
+		It("prefers KAIROS_AGENT_BIN when the file exists", func() {
+			dir := GinkgoT().TempDir()
+			bin := filepath.Join(dir, "fake-agent")
+			Expect(os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755)).To(Succeed())
+			GinkgoT().Setenv(agentrun.EnvAgentBin, bin)
+			Expect(agentrun.ResolveAgentBin()).To(Equal(bin))
+		})
+
+		It("falls back to kairos-agent on PATH", func() {
+			GinkgoT().Setenv(agentrun.EnvAgentBin, "")
+			dir := GinkgoT().TempDir()
+			bin := filepath.Join(dir, "kairos-agent")
+			Expect(os.WriteFile(bin, []byte("#!/bin/sh\n"), 0o755)).To(Succeed())
+			GinkgoT().Setenv("PATH", dir)
+			Expect(agentrun.ResolveAgentBin()).To(Equal(bin))
+		})
+
+		It("returns empty when nothing is found", func() {
+			GinkgoT().Setenv(agentrun.EnvAgentBin, "")
+			GinkgoT().Setenv("PATH", GinkgoT().TempDir())
+			Expect(agentrun.ResolveAgentBin()).To(BeEmpty())
+		})
+	})
+
+	Describe("Command", func() {
+		It("builds manual-install with source, finish flag, default dirs and progress env", func() {
+			cmd := agentrun.Command("/usr/bin/kairos-agent", "/tmp/cc.yaml", "oci://x:y", "reboot")
+			Expect(cmd.Args).To(Equal([]string{
+				"/usr/bin/kairos-agent", "manual-install",
+				"--source", "oci://x:y",
+				"--use-default-dirs",
+				"--reboot",
+				"/tmp/cc.yaml",
+			}))
+			Expect(cmd.Env).To(ContainElement("KAIROS_AGENT_PROGRESS=1"))
+		})
+
+		It("omits the finish flag when action is nothing", func() {
+			cmd := agentrun.Command("/usr/bin/kairos-agent", "/tmp/cc.yaml", "", "nothing")
+			Expect(cmd.Args).To(Equal([]string{
+				"/usr/bin/kairos-agent", "manual-install",
+				"--use-default-dirs",
+				"/tmp/cc.yaml",
+			}))
+		})
+
+		It("uses --poweroff for the poweroff action", func() {
+			cmd := agentrun.Command("/usr/bin/kairos-agent", "/tmp/cc.yaml", "", "poweroff")
+			Expect(cmd.Args).To(ContainElement("--poweroff"))
+		})
+	})
+
+	Describe("ParseLine", func() {
+		It("parses a step event", func() {
+			ev, ok := agentrun.ParseLine([]byte(`{"event":"step","step":"partition"}`))
+			Expect(ok).To(BeTrue())
+			Expect(ev.Event).To(Equal("step"))
+			Expect(ev.Step).To(Equal("partition"))
+		})
+
+		It("parses an error event", func() {
+			ev, ok := agentrun.ParseLine([]byte(`{"event":"error","message":"boom"}`))
+			Expect(ok).To(BeTrue())
+			Expect(ev.Event).To(Equal("error"))
+			Expect(ev.Message).To(Equal("boom"))
+		})
+
+		It("rejects a plain log line", func() {
+			_, ok := agentrun.ParseLine([]byte(`time=... level=info msg=hello`))
+			Expect(ok).To(BeFalse())
+		})
+
+		It("rejects JSON without an event field", func() {
+			_, ok := agentrun.ParseLine([]byte(`{"level":"info","message":"hi"}`))
+			Expect(ok).To(BeFalse())
+		})
+	})
+
+	Describe("Run", func() {
+		It("streams events and reports a clean exit", func() {
+			dir := GinkgoT().TempDir()
+			bin := filepath.Join(dir, "kairos-agent")
+			script := "#!/bin/sh\n" +
+				`echo '{"event":"step","step":"partition"}'` + "\n" +
+				`echo 'some plain log line'` + "\n" +
+				`echo '{"event":"step","step":"done"}'` + "\n" +
+				"exit 0\n"
+			Expect(os.WriteFile(bin, []byte(script), 0o755)).To(Succeed())
+
+			var steps []string
+			err := agentrun.Run(bin, "/tmp/cc.yaml", "", "nothing",
+				func(ev agentrun.ProgressEvent) {
+					if ev.Event == "step" {
+						steps = append(steps, ev.Step)
+					}
+				},
+				func(string) {},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(steps).To(Equal([]string{"partition", "done"}))
+		})
+
+		It("returns the exit error when the agent fails", func() {
+			dir := GinkgoT().TempDir()
+			bin := filepath.Join(dir, "kairos-agent")
+			Expect(os.WriteFile(bin, []byte("#!/bin/sh\nexit 5\n"), 0o755)).To(Succeed())
+			err := agentrun.Run(bin, "/tmp/cc.yaml", "", "nothing",
+				func(agentrun.ProgressEvent) {}, func(string) {})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/agentrun/suite_test.go
+++ b/agentrun/suite_test.go
@@ -1,0 +1,13 @@
+package agentrun_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAgentRun(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AgentRun test suite")
+}


### PR DESCRIPTION
A TUI-free helper that implements the installer side of the kairos-agent installer contract: resolve the agent binary, build a manual-install invocation, run it with progress emission enabled, and parse the agent's JSON-Lines progress stream into structured events.

Moved here from kairos-installer's internal/agentrun so any installer frontend can reuse it instead of copying the contract implementation.