### PR TITLE
feat(agentrun): add installer-contract constants (events, steps, env)

### DIFF
--- a/agentrun/agentrun.go
+++ b/agentrun/agentrun.go
@@ -18,6 +18,45 @@ import (
 // EnvAgentBin overrides agent discovery with an explicit path.
 const EnvAgentBin = "KAIROS_AGENT_BIN"
 
+// Contract vocabulary — the JSON-Lines progress protocol that kairos-agent
+// emits and installer frontends consume. Both sides should reference these
+// constants instead of hard-coding the strings.
+const (
+	// EnvProgress, when set to a non-empty value in the agent's environment,
+	// makes kairos-agent emit progress events on stdout.
+	EnvProgress = "KAIROS_AGENT_PROGRESS"
+
+	// Event values for ProgressEvent.Event.
+	EventStep  = "step"
+	EventError = "error"
+)
+
+// Step values for ProgressEvent.Step, in the order the agent emits them.
+const (
+	StepPartition     = "partition"
+	StepBeforeInstall = "before-install"
+	StepActive        = "active"
+	StepBootloader    = "bootloader"
+	StepRecovery      = "recovery"
+	StepPassive       = "passive"
+	StepAfterInstall  = "after-install"
+	StepDone          = "done"
+)
+
+// Steps lists the step events in the order the agent emits them on a full,
+// successful install. Steps that do not run (e.g. partition on a NoFormat
+// install) are simply omitted from the stream.
+var Steps = []string{
+	StepPartition,
+	StepBeforeInstall,
+	StepActive,
+	StepBootloader,
+	StepRecovery,
+	StepPassive,
+	StepAfterInstall,
+	StepDone,
+}
+
 // agentBinName is the fixed name looked up on PATH.
 const agentBinName = "kairos-agent"
 
@@ -60,7 +99,7 @@ func Command(agentBin, cfgPath, source, finishAction string) *exec.Cmd {
 	args = append(args, cfgPath)
 
 	cmd := exec.Command(agentBin, args...)
-	cmd.Env = append(os.Environ(), "KAIROS_AGENT_PROGRESS=1")
+	cmd.Env = append(os.Environ(), EnvProgress+"=1")
 	return cmd
 }
 

--- a/agentrun/agentrun_test.go
+++ b/agentrun/agentrun_test.go
@@ -124,3 +124,17 @@ var _ = Describe("agentrun", func() {
 		})
 	})
 })
+
+var _ = Describe("contract constants", func() {
+	It("exposes the step vocabulary in emission order", func() {
+		Expect(agentrun.Steps).To(Equal([]string{
+			"partition", "before-install", "active", "bootloader",
+			"recovery", "passive", "after-install", "done",
+		}))
+	})
+	It("names the progress env var and event values", func() {
+		Expect(agentrun.EnvProgress).To(Equal("KAIROS_AGENT_PROGRESS"))
+		Expect(agentrun.EventStep).To(Equal("step"))
+		Expect(agentrun.EventError).To(Equal("error"))
+	})
+})


### PR DESCRIPTION
The JSON-Lines progress vocabulary (KAIROS_AGENT_PROGRESS, the "step"/ "error" event values, and the ordered step names partition..done) is the contract between kairos-agent (emitter) and installer frontends (consumers). Define it once here so both sides reference the SDK instead of hard-coding strings. Command() now uses EnvProgress.