### PR TITLE
fix(ghw): skip kernel-hidden block devices in GetDisks

### DIFF
--- a/ghw/ghw.go
+++ b/ghw/ghw.go
@@ -113,6 +113,17 @@ func GetDisks(paths *Paths, logger *sdkLogger.KairosLogger) []*partitions.Disk {
 			// We don't care about unused loop devices...
 			continue
 		}
+
+		// Skip kernel-hidden block devices (/sys/block/<dev>/hidden == 1).
+		// These include the NVMe per-controller path device (nvmeXcYnZ)
+		// exposed by native NVMe multipath, which shadows the real namespace
+		// (nvmeXnY) with the same size but has no usable /dev node. Returning
+		// it makes callers pick an unusable install target that fails with
+		// "Disk /dev/nvmeXcYnZ does not exist".
+		if isHiddenDevice(paths, dname) {
+			logger.Logger.Trace().Str("file", dname).Msg("Skipping hidden device")
+			continue
+		}
 		d := &partitions.Disk{
 			Name:      dname,
 			SizeBytes: size,
@@ -151,6 +162,17 @@ func isMultipathPartition(entry os.DirEntry, paths *Paths, logger *sdkLogger.Kai
 	// this is the primary check for multipath partitions and should be safe.
 	_, ok := udevInfo["DM_PART"]
 	return ok
+}
+
+// isHiddenDevice reports whether the block device is marked hidden by the
+// kernel via /sys/block/<dev>/hidden == 1. A missing attribute is treated as
+// not hidden, matching devices/kernels that do not expose it.
+func isHiddenDevice(paths *Paths, disk string) bool {
+	contents, err := os.ReadFile(filepath.Join(paths.SysBlock, disk, "hidden"))
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(contents)) == "1"
 }
 
 func diskSizeBytes(paths *Paths, disk string, logger *sdkLogger.KairosLogger) uint64 {

--- a/ghw/ghw_test.go
+++ b/ghw/ghw_test.go
@@ -1,6 +1,8 @@
 package ghw_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/kairos-io/kairos-sdk/ghw"
@@ -66,6 +68,26 @@ var _ = Describe("GHW functions tests", func() {
 			ghwMock.CreateDevices()
 			disks := ghw.GetDisks(ghw.NewPaths(ghwMock.Chroot), nil)
 			Expect(len(disks)).To(Equal(0), disks)
+		})
+	})
+
+	Describe("With a kernel-hidden device", func() {
+		It("Skips the hidden device and returns only the real one", func() {
+			// Native NVMe multipath exposes the per-controller path device
+			// (nvme1c1n1) alongside the real namespace (nvme1n1). The path
+			// device is marked hidden (/sys/block/<dev>/hidden == 1) and must
+			// not be returned: it has no usable /dev node.
+			ghwMock.AddDisk(partitions.Disk{Name: "nvme1n1", UUID: "aaa", SizeBytes: 100})
+			ghwMock.AddDisk(partitions.Disk{Name: "nvme1c1n1", UUID: "bbb", SizeBytes: 100})
+			ghwMock.CreateDevices()
+			// The mock does not write the hidden attribute, so set it like the
+			// kernel does for the per-controller path device.
+			hiddenPath := filepath.Join(ghwMock.Chroot, "sys", "block", "nvme1c1n1", "hidden")
+			Expect(os.WriteFile(hiddenPath, []byte("1\n"), 0644)).To(Succeed())
+
+			disks := ghw.GetDisks(ghw.NewPaths(ghwMock.Chroot), nil)
+			Expect(len(disks)).To(Equal(1), disks)
+			Expect(disks[0].Name).To(Equal("nvme1n1"), disks)
 		})
 	})
 


### PR DESCRIPTION
Native NVMe multipath exposes a per-controller path device (nvmeXcYnZ) alongside the real namespace (nvmeXnY). The kernel marks it hidden via /sys/block/<dev>/hidden == 1; it reports the same size but has no usable /dev node. Returning it makes callers (e.g. kairos-agent install target auto-detection) pick an unusable device that fails with "Disk /dev/nvmeXcYnZ does not exist".

Skip any device whose /sys/block/<dev>/hidden reads 1, alongside the existing dm-/multipath/loop handling. A missing attribute is treated as not hidden.