### PR TITLE
Add installer path constants and resolution helpers

### DIFF
--- a/constants/constants.go
+++ b/constants/constants.go
@@ -36,3 +36,13 @@ const (
 	PersistentSize = uint(0)     // Size of the PERSISTENT partition in MiB by default. Set to 0 so its expanded to fill remaining space
 	ImgSize        = uint(3072)  // Size of the image files in MiB by default. For active/passive/recovery.img
 )
+
+// Installer binary locations. These define the contract, shared across kairos
+// projects, for where the installer lives in an image: kairos-init bundles the
+// default and kairos-agent execs whichever is resolved at install time. The
+// resolution helpers live in the installer package.
+const (
+	InstallerDefaultPath  = "/system/installer/kairos-installer" // Default installer path, bundled by kairos-init
+	InstallerOverridePath = "/system/installer/installer"        // Override slot the base image or user can drop their own installer into; takes precedence over the default
+	InstallerEnvVar       = "KAIROS_INSTALLER"                   // Env var that, when set to an existing path, overrides both installer locations
+)

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -1,0 +1,50 @@
+// Package installer holds the contract for locating the kairos installer binary
+// within an image. It is shared across kairos projects: kairos-init bundles the
+// default installer (and skips bundling when one is already present, via
+// Existing), while kairos-agent resolves and execs the installer at install time
+// (via Resolve).
+package installer
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/kairos-io/kairos-sdk/constants"
+)
+
+// Existing reports whether an installer is already present under root, returning
+// its path. It checks the override slot first and then the default path,
+// mirroring the resolution order. It ignores the KAIROS_INSTALLER env var, which
+// is a runtime override rather than an image-build signal.
+//
+// root is prefixed to the candidate paths so callers can point it at a test
+// directory; production callers pass "/".
+func Existing(root string) (string, bool) {
+	for _, p := range []string{constants.InstallerOverridePath, constants.InstallerDefaultPath} {
+		full := filepath.Join(root, p)
+		if _, err := os.Stat(full); err == nil {
+			return full, true
+		}
+	}
+	return "", false
+}
+
+// Resolve returns the path to an installer binary, or "" if none is found.
+// Resolution order matches the installer contract:
+//
+//	$KAIROS_INSTALLER (when set and existing) -> override path -> default path.
+//
+// root is prefixed to the override and default paths so callers can point it at
+// a test directory; production callers pass "/". The KAIROS_INSTALLER value is an
+// explicit absolute path and is never prefixed with root.
+func Resolve(root string) string {
+	if p := os.Getenv(constants.InstallerEnvVar); p != "" {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	if path, found := Existing(root); found {
+		return path
+	}
+	return ""
+}

--- a/installer/installer_suite_test.go
+++ b/installer/installer_suite_test.go
@@ -1,0 +1,13 @@
+package installer_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestInstaller(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Installer Suite")
+}

--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -1,0 +1,97 @@
+package installer_test
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/kairos-io/kairos-sdk/constants"
+	"github.com/kairos-io/kairos-sdk/installer"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// seed creates a fake installer binary at path (relative to root) and returns
+// its absolute path.
+func seed(root, path string) string {
+	full := filepath.Join(root, path)
+	Expect(os.MkdirAll(filepath.Dir(full), 0755)).To(Succeed())
+	Expect(os.WriteFile(full, []byte("installer"), 0755)).To(Succeed())
+	return full
+}
+
+var _ = Describe("Existing", func() {
+	var root string
+
+	BeforeEach(func() {
+		root = GinkgoT().TempDir()
+	})
+
+	It("reports no installer when none is present", func() {
+		path, found := installer.Existing(root)
+		Expect(found).To(BeFalse())
+		Expect(path).To(BeEmpty())
+	})
+
+	It("finds the default path", func() {
+		want := seed(root, constants.InstallerDefaultPath)
+		path, found := installer.Existing(root)
+		Expect(found).To(BeTrue())
+		Expect(path).To(Equal(want))
+	})
+
+	It("finds the override path", func() {
+		want := seed(root, constants.InstallerOverridePath)
+		path, found := installer.Existing(root)
+		Expect(found).To(BeTrue())
+		Expect(path).To(Equal(want))
+	})
+
+	It("prefers the override path over the default", func() {
+		seed(root, constants.InstallerDefaultPath)
+		want := seed(root, constants.InstallerOverridePath)
+		path, found := installer.Existing(root)
+		Expect(found).To(BeTrue())
+		Expect(path).To(Equal(want))
+	})
+})
+
+var _ = Describe("Resolve", func() {
+	var root string
+
+	BeforeEach(func() {
+		root = GinkgoT().TempDir()
+		// Ensure no ambient env override leaks into the cases that don't set it.
+		GinkgoT().Setenv(constants.InstallerEnvVar, "")
+	})
+
+	It("returns empty when nothing is present", func() {
+		Expect(installer.Resolve(root)).To(BeEmpty())
+	})
+
+	It("falls back to the override path", func() {
+		want := seed(root, constants.InstallerOverridePath)
+		Expect(installer.Resolve(root)).To(Equal(want))
+	})
+
+	It("falls back to the default path", func() {
+		want := seed(root, constants.InstallerDefaultPath)
+		Expect(installer.Resolve(root)).To(Equal(want))
+	})
+
+	It("honors KAIROS_INSTALLER over the fixed paths", func() {
+		// A fixed path exists, but the env override points elsewhere and wins.
+		seed(root, constants.InstallerDefaultPath)
+		envPath := filepath.Join(GinkgoT().TempDir(), "custom-installer")
+		Expect(os.WriteFile(envPath, []byte("installer"), 0755)).To(Succeed())
+		GinkgoT().Setenv(constants.InstallerEnvVar, envPath)
+
+		Expect(installer.Resolve(root)).To(Equal(envPath))
+	})
+
+	It("ignores KAIROS_INSTALLER when it points at a missing file", func() {
+		want := seed(root, constants.InstallerDefaultPath)
+		GinkgoT().Setenv(constants.InstallerEnvVar, filepath.Join(root, "does-not-exist"))
+
+		Expect(installer.Resolve(root)).To(Equal(want))
+	})
+})


### PR DESCRIPTION
The kairos installer's image locations (default, override slot, and the KAIROS_INSTALLER env override) are a contract shared between kairos-init (which bundles the default installer) and kairos-agent (which execs the resolved installer at install time). Until now each repo hardcoded these paths privately, so define them once here.

Add the constants to the constants package and a small installer package with two helpers:
  - Existing: build-time check used by kairos-init to skip bundling its embedded installer when one is already present.
  - Resolve: runtime resolution (env -> override -> default) used by kairos-agent to locate the installer to exec.

Both take a root prefix for hermetic testing.