### PR TITLE
feat(agentrun): add RunWithOutput to capture the full agent transcript

### DIFF
--- a/agentrun/agentrun.go
+++ b/agentrun/agentrun.go
@@ -11,8 +11,10 @@ package agentrun
 import (
 	"bufio"
 	"encoding/json"
+	"io"
 	"os"
 	"os/exec"
+	"sync"
 )
 
 // EnvAgentBin overrides agent discovery with an explicit path.
@@ -118,14 +120,39 @@ func ParseLine(line []byte) (ProgressEvent, bool) {
 }
 
 // Run execs the agent, calling onEvent for each progress event and onLog for
-// each non-event stdout line. It returns the process exit error, if any.
+// each non-event stdout line. The agent's stderr is forwarded to os.Stderr.
+// It returns the process exit error, if any.
 func Run(agentBin, cfgPath, source, finishAction string, onEvent func(ProgressEvent), onLog func(string)) error {
+	return run(agentBin, cfgPath, source, finishAction, onEvent, onLog, os.Stderr, nil)
+}
+
+// RunWithOutput behaves like Run but additionally tees the agent's complete
+// output into out: every raw stdout line (progress JSON included), each
+// followed by a newline, plus the agent's stderr stream. It is intended for
+// capturing a full agent transcript in debug bundles. Writes from the stdout
+// and stderr streams are serialized, so out need not be safe for concurrent
+// use.
+//
+// If out is nil, RunWithOutput behaves like Run except the agent's stderr is
+// discarded instead of forwarded to os.Stderr.
+func RunWithOutput(agentBin, cfgPath, source, finishAction string, onEvent func(ProgressEvent), onLog func(string), out io.Writer) error {
+	if out == nil {
+		return run(agentBin, cfgPath, source, finishAction, onEvent, onLog, io.Discard, nil)
+	}
+	w := &lockedWriter{w: out}
+	return run(agentBin, cfgPath, source, finishAction, onEvent, onLog, w, w)
+}
+
+// run is the shared implementation behind Run and RunWithOutput. stderr
+// receives the agent's stderr stream; when stdoutTee is non-nil, each raw
+// stdout line is written to it (with a trailing newline) before being parsed.
+func run(agentBin, cfgPath, source, finishAction string, onEvent func(ProgressEvent), onLog func(string), stderr, stdoutTee io.Writer) error {
 	cmd := Command(agentBin, cfgPath, source, finishAction)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return err
 	}
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = stderr
 	if err := cmd.Start(); err != nil {
 		return err
 	}
@@ -134,6 +161,10 @@ func Run(agentBin, cfgPath, source, finishAction string, onEvent func(ProgressEv
 	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	for scanner.Scan() {
 		line := scanner.Bytes()
+		if stdoutTee != nil {
+			_, _ = stdoutTee.Write(line)
+			_, _ = stdoutTee.Write([]byte{'\n'})
+		}
 		if ev, ok := ParseLine(line); ok {
 			onEvent(ev)
 		} else if len(line) > 0 {
@@ -141,4 +172,18 @@ func Run(agentBin, cfgPath, source, finishAction string, onEvent func(ProgressEv
 		}
 	}
 	return cmd.Wait()
+}
+
+// lockedWriter serializes concurrent writes to an underlying writer, so the
+// agent's stdout-tee (written from the scan loop) and stderr (written from the
+// os/exec copy goroutine) can safely share a single destination.
+type lockedWriter struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
 }

--- a/agentrun/agentrun_test.go
+++ b/agentrun/agentrun_test.go
@@ -3,6 +3,7 @@ package agentrun_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -120,6 +121,73 @@ var _ = Describe("agentrun", func() {
 			Expect(os.WriteFile(bin, []byte("#!/bin/sh\nexit 5\n"), 0o755)).To(Succeed())
 			err := agentrun.Run(bin, "/tmp/cc.yaml", "", "nothing",
 				func(agentrun.ProgressEvent) {}, func(string) {})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("RunWithOutput", func() {
+		It("tees the full agent transcript (raw stdout + stderr) into out", func() {
+			dir := GinkgoT().TempDir()
+			bin := filepath.Join(dir, "kairos-agent")
+			script := "#!/bin/sh\n" +
+				`echo '{"event":"step","step":"partition"}'` + "\n" +
+				"echo 'plain log line'\n" +
+				"echo 'a stderr warning' 1>&2\n" +
+				`echo '{"event":"step","step":"done"}'` + "\n" +
+				"exit 0\n"
+			Expect(os.WriteFile(bin, []byte(script), 0o755)).To(Succeed())
+
+			var out strings.Builder
+			var steps, logs []string
+			err := agentrun.RunWithOutput(bin, "/tmp/cc.yaml", "", "nothing",
+				func(ev agentrun.ProgressEvent) {
+					if ev.Event == agentrun.EventStep {
+						steps = append(steps, ev.Step)
+					}
+				},
+				func(line string) { logs = append(logs, line) },
+				&out,
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Callbacks still fire exactly as with Run.
+			Expect(steps).To(Equal([]string{"partition", "done"}))
+			Expect(logs).To(Equal([]string{"plain log line"}))
+
+			// out captures the complete transcript: raw stdout (progress JSON
+			// included) AND stderr.
+			transcript := out.String()
+			Expect(transcript).To(ContainSubstring(`{"event":"step","step":"partition"}`))
+			Expect(transcript).To(ContainSubstring("plain log line"))
+			Expect(transcript).To(ContainSubstring(`{"event":"step","step":"done"}`))
+			Expect(transcript).To(ContainSubstring("a stderr warning"))
+		})
+
+		It("still parses events when out is nil", func() {
+			dir := GinkgoT().TempDir()
+			bin := filepath.Join(dir, "kairos-agent")
+			script := "#!/bin/sh\n" +
+				`echo '{"event":"step","step":"done"}'` + "\n" +
+				"exit 0\n"
+			Expect(os.WriteFile(bin, []byte(script), 0o755)).To(Succeed())
+
+			var steps []string
+			err := agentrun.RunWithOutput(bin, "/tmp/cc.yaml", "", "nothing",
+				func(ev agentrun.ProgressEvent) { steps = append(steps, ev.Step) },
+				func(string) {},
+				nil,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(steps).To(Equal([]string{"done"}))
+		})
+
+		It("returns the exit error when the agent fails", func() {
+			dir := GinkgoT().TempDir()
+			bin := filepath.Join(dir, "kairos-agent")
+			Expect(os.WriteFile(bin, []byte("#!/bin/sh\nexit 5\n"), 0o755)).To(Succeed())
+			var out strings.Builder
+			err := agentrun.RunWithOutput(bin, "/tmp/cc.yaml", "", "nothing",
+				func(agentrun.ProgressEvent) {}, func(string) {}, &out)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
Run parses stdout (progress events / log lines) and forwards stderr to os.Stderr, so nothing captures the agent's complete output. TUI frontends running in an alt-screen also can't let stderr hit os.Stderr without corrupting the display.

RunWithOutput tees the full transcript — every raw stdout line (progress JSON included) plus stderr — into a caller-provided io.Writer, so installer frontends can persist it into a debug bundle. Stdout-tee and stderr writes are serialized via a small locked writer, so the destination need not be concurrency-safe. Passing nil discards stderr (alt-screen safe) and behaves like Run otherwise. Run is unchanged (delegates to a shared helper).

https://github.com/kairos-io/kairos-installer/pull/9