### PR TITLE
feat(constants): add shared kairos-agent install path contract

### DIFF
--- a/agentrun/agentrun.go
+++ b/agentrun/agentrun.go
@@ -15,10 +15,12 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+
+	"github.com/kairos-io/kairos-sdk/constants"
 )
 
 // EnvAgentBin overrides agent discovery with an explicit path.
-const EnvAgentBin = "KAIROS_AGENT_BIN"
+const EnvAgentBin = constants.AgentEnvVar
 
 // Contract vocabulary — the JSON-Lines progress protocol that kairos-agent
 // emits and installer frontends consume. Both sides should reference these
@@ -59,9 +61,6 @@ var Steps = []string{
 	StepDone,
 }
 
-// agentBinName is the fixed name looked up on PATH.
-const agentBinName = "kairos-agent"
-
 // ProgressEvent is one parsed JSON-Lines progress line from the agent.
 type ProgressEvent struct {
 	Event   string `json:"event"`
@@ -69,15 +68,20 @@ type ProgressEvent struct {
 	Message string `json:"message"`
 }
 
-// ResolveAgentBin returns the kairos-agent path: KAIROS_AGENT_BIN (must exist)
-// then kairos-agent on PATH, else "".
+// ResolveAgentBin returns the kairos-agent path. Resolution order matches the
+// agent contract shared with kairos-init:
+//
+//	$KAIROS_AGENT_BIN (when set and existing) -> AgentDefaultPath -> kairos-agent on PATH.
 func ResolveAgentBin() string {
-	if p := os.Getenv(EnvAgentBin); p != "" {
+	if p := os.Getenv(constants.AgentEnvVar); p != "" {
 		if _, err := os.Stat(p); err == nil {
 			return p
 		}
 	}
-	if p, err := exec.LookPath(agentBinName); err == nil {
+	if _, err := os.Stat(constants.AgentDefaultPath); err == nil {
+		return constants.AgentDefaultPath
+	}
+	if p, err := exec.LookPath(constants.AgentBinName); err == nil {
 		return p
 	}
 	return ""

--- a/agentrun/agentrun_test.go
+++ b/agentrun/agentrun_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/kairos-io/kairos-sdk/agentrun"
+	"github.com/kairos-io/kairos-sdk/constants"
 )
 
 var _ = Describe("agentrun", func() {
@@ -21,7 +22,10 @@ var _ = Describe("agentrun", func() {
 			Expect(agentrun.ResolveAgentBin()).To(Equal(bin))
 		})
 
-		It("falls back to kairos-agent on PATH", func() {
+		It("falls back to kairos-agent on PATH when AgentDefaultPath is absent", func() {
+			if _, err := os.Stat(constants.AgentDefaultPath); err == nil {
+				Skip(constants.AgentDefaultPath + " is present on this system")
+			}
 			GinkgoT().Setenv(agentrun.EnvAgentBin, "")
 			dir := GinkgoT().TempDir()
 			bin := filepath.Join(dir, "kairos-agent")
@@ -31,6 +35,9 @@ var _ = Describe("agentrun", func() {
 		})
 
 		It("returns empty when nothing is found", func() {
+			if _, err := os.Stat(constants.AgentDefaultPath); err == nil {
+				Skip(constants.AgentDefaultPath + " is present on this system")
+			}
 			GinkgoT().Setenv(agentrun.EnvAgentBin, "")
 			GinkgoT().Setenv("PATH", GinkgoT().TempDir())
 			Expect(agentrun.ResolveAgentBin()).To(BeEmpty())
@@ -204,5 +211,10 @@ var _ = Describe("contract constants", func() {
 		Expect(agentrun.EnvProgress).To(Equal("KAIROS_AGENT_PROGRESS"))
 		Expect(agentrun.EventStep).To(Equal("step"))
 		Expect(agentrun.EventError).To(Equal("error"))
+	})
+	It("names the agent install contract", func() {
+		Expect(constants.AgentBinName).To(Equal("kairos-agent"))
+		Expect(constants.AgentDefaultPath).To(Equal("/usr/bin/kairos-agent"))
+		Expect(agentrun.EnvAgentBin).To(Equal(constants.AgentEnvVar))
 	})
 })

--- a/constants/constants.go
+++ b/constants/constants.go
@@ -46,3 +46,12 @@ const (
 	InstallerOverridePath = "/system/installer/installer"        // Override slot the base image or user can drop their own installer into; takes precedence over the default
 	InstallerEnvVar       = "KAIROS_INSTALLER"                   // Env var that, when set to an existing path, overrides both installer locations
 )
+
+// Agent binary location. kairos-init installs kairos-agent to AgentDefaultPath;
+// kairos-agent systemd units and phone-home services must use the same path.
+// Resolution helpers live in the agentrun package.
+const (
+	AgentBinName     = "kairos-agent"
+	AgentDefaultPath = "/usr/bin/kairos-agent"
+	AgentEnvVar      = "KAIROS_AGENT_BIN" // Env var override for dev/tests; must point at an existing binary
+)


### PR DESCRIPTION
## Summary

- Add `AgentBinName`, `AgentDefaultPath` (`/usr/bin/kairos-agent`), and `AgentEnvVar` (`KAIROS_AGENT_BIN`) to `constants`, mirroring the existing installer path contract.
- Update `agentrun.ResolveAgentBin` to resolve: env override → default path → PATH.
- Keep `agentrun.EnvAgentBin` as an alias of `constants.AgentEnvVar` for backward compatibility.

## Motivation

While fixing AuroraBoot phone-home registration ([AuroraBoot#580](https://github.com/kairos-io/AuroraBoot/pull/580)), we found kairos-init installs `kairos-agent` to `/usr/bin/kairos-agent` but kairos-agent's phone-home systemd unit hardcoded `/usr/sbin/kairos-agent`, causing `203/EXEC` and failed node registration.

Since Kairos owns all image builds, the install path should be a shared contract in kairos-sdk — not duplicated (or wrong) in each repo.

Tracking epic: kairos-io/kairos#4189

## Follow-ups (after merge)

- kairos-io/kairos#4190 — kairos-agent phone-home service
- kairos-io/kairos#4191 — kairos-init installer paths

## Test plan

- [x] `go test ./agentrun/...`
- [x] CI unit-tests job