### PR TITLE
feat: power off immediately with `shutdown now`

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -264,11 +264,18 @@ func Reboot() {
 
 func PowerOFF() {
 	pterm.Info.Println("Shutdown node")
-	if IsOpenRCBased() {
-		SH("poweroff") //nolint:errcheck
-	} else {
-		SH("shutdown") //nolint:errcheck
+	SH(poweroffCommand(IsOpenRCBased())) //nolint:errcheck
+}
+
+// poweroffCommand returns the command used to power the node off. On systemd
+// based systems `shutdown` defaults to a one minute delay, so `shutdown now` is
+// used to power off immediately. openRC based systems use `poweroff`, which
+// already takes effect immediately.
+func poweroffCommand(openRC bool) string {
+	if openRC {
+		return "poweroff"
 	}
+	return "shutdown now"
 }
 
 func ListToOutput(rels []string, output string) []string {

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -60,3 +60,29 @@ func TestGetEfiShimFiles(t *testing.T) {
 		t.Fatalf("GetEfiShimFiles(\"riscv64\") = %v, want no shim paths", riscv64Files)
 	}
 }
+
+func TestPoweroffCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		openRC   bool
+		expected string
+	}{
+		{
+			name:     "systemd based uses shutdown now to avoid the default one minute delay",
+			openRC:   false,
+			expected: "shutdown now",
+		},
+		{
+			name:     "openRC based uses poweroff",
+			openRC:   true,
+			expected: "poweroff",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := poweroffCommand(tt.openRC); got != tt.expected {
+				t.Fatalf("poweroffCommand(%v) = %q, want %q", tt.openRC, got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
On systemd based systems the bare `shutdown` command schedules the poweroff one minute into the future. Combined with the 5 second grace period kairos-agent already waits, a non-interactive shutdown took over a minute to take effect.

Use `shutdown now` so the poweroff happens immediately once the grace period has elapsed. openRC based systems keep using `poweroff`, which is already immediate. The command selection is extracted into a pure `poweroffCommand` helper so it can be unit tested without executing the command.

Refs kairos-io/kairos#3126