### PR TITLE
fix(utils): add openSUSE riscv64 GRUB EFI path to GetEfiGrubFiles

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -339,6 +339,8 @@ func GetEfiGrubFiles(arch string) []string {
 		modNames = append(modNames, "/usr/lib/grub/arm64-efi/grubaa64.efi")               // hadron
 
 	case "riscv64":
+		// openSUSE / SLE layout (grub2-riscv64-efi):
+		modNames = append(modNames, "/usr/share/efi/riscv64/grub.efi")
 		// Verified Debian 13 modules path:
 		// https://packages.debian.org/trixie/riscv64/grub-efi-riscv64-bin/filelist
 		modNames = append(modNames, "/usr/lib/grub/riscv64-efi/grubriscv64.efi")

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -18,6 +18,7 @@ func TestGetEfiGrubFiles(t *testing.T) {
 		{
 			arch: "riscv64",
 			expected: []string{
+				"/usr/share/efi/riscv64/grub.efi",
 				"/usr/lib/grub/riscv64-efi/grubriscv64.efi",
 				"/usr/lib/grub/riscv64-efi/monolithic/grubriscv64.efi",
 				"/boot/efi/EFI/debian/grubriscv64.efi",


### PR DESCRIPTION
## Summary
- Add `/usr/share/efi/riscv64/grub.efi` to `GetEfiGrubFiles("riscv64")` — the path used by openSUSE/SLE `grub2-riscv64-efi`
- Extend the existing riscv64 unit test to cover the new path

Complements kairos-io/AuroraBoot#635 (merged), which prepends the same path for ISO builds. **kairos-agent** uses `GetEfiGrubFiles()` directly during EFI install, so this SDK change is required for openSUSE riscv64 manual install to find grub without Dockerfile symlinks.

Part of kairos-io/kairos#4083 (riscv64 support).

## Test plan
- [x] `go test ./utils/...` — `TestGetEfiGrubFiles` includes openSUSE path
- [ ] Manual: openSUSE Tumbleweed riscv64 core image EFI install finds grub at `/usr/share/efi/riscv64/grub.efi`


Made with [Cursor](https://cursor.com)