### PR TITLE
feat(cmdline): centralize kairos.config and cos.setup parsing

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -262,6 +262,12 @@ func Scan(o *Options, filter func(d []byte) ([]byte, error)) (*Config, error) {
 		if err == nil { // best-effort
 			configs = append(configs, cConfig)
 		}
+
+		kConfig, err := ParseKairosCmdline(o.BootCMDLineFile)
+		o.SoftErr("parsing kairos.config cmdline stanzas", err)
+		if err == nil && len(kConfig.Values) > 0 {
+			configs = append(configs, kConfig)
+		}
 	}
 
 	mergedConfig, err := configs.Merge()
@@ -419,6 +425,34 @@ func ParseCmdLine(file string, filter func(d []byte) ([]byte, error)) (*Config, 
 	}
 
 	return &result, nil
+}
+
+// ParseKairosCmdline builds a Config from every "kairos.config=KEY=VALUE"
+// stanza found on the given cmdline file (defaults to /proc/cmdline when
+// empty). KEY supports dot notation for nested maps, e.g.
+//
+//	kairos.config=config_url=https://example.com/extra.yaml
+//	kairos.config=hostname=box
+//	kairos.config=install.auto=true
+//
+// List/array indices in the key are not supported. Repeated stanzas are
+// merged; the last value for a given key wins. Returns a Config with an
+// empty Values map when nothing is set so callers can merge it
+// unconditionally. Call MergeConfigURL on the result to recursively pull
+// any remote config referenced through config_url.
+func ParseKairosCmdline(file string) (*Config, error) {
+	result := &Config{Sources: []string{"cmdline"}, Values: ConfigValues{}}
+	y, err := machine.KairosCmdlineYAML(file)
+	if err != nil {
+		return result, err
+	}
+	if y == nil {
+		return result, nil
+	}
+	if err := yaml.Unmarshal(y, &result.Values); err != nil {
+		return result, err
+	}
+	return result, nil
 }
 
 // ConfigURL returns the value of config_url if set or empty string otherwise.

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -408,10 +408,10 @@ func listFiles(dir string) ([]string, error) {
 // ParseCmdLine reads options from the kernel cmdline and returns the equivalent
 // Config. It treats every KEY=VALUE token on the cmdline as config and relies
 // on the caller-supplied filter to drop non-config kernel args. Tokens using
-// the namespaced kairos.config= and cos.setup= forms are skipped here because
-// they have dedicated parsers (ParseKairosCmdline / machine.CosSetupURI); use
-// those for the namespaced form (no filter required, supports quoted values
-// with spaces).
+// any Kairos-owned prefix (kairos.config=, kairos.config_url=, cos.setup=) are
+// skipped here so they flow exclusively through ParseKairosCmdline, which
+// supports quoted values with spaces, list indices and a dedicated
+// kairos.config_url= URL form.
 func ParseCmdLine(file string, filter func(d []byte) ([]byte, error)) (*Config, error) {
 	result := Config{Sources: []string{"cmdline"}}
 	dotToYAML, err := machine.DotToYAML(file)
@@ -432,19 +432,22 @@ func ParseCmdLine(file string, filter func(d []byte) ([]byte, error)) (*Config, 
 	return &result, nil
 }
 
-// ParseKairosCmdline builds a Config from every "kairos.config=KEY=VALUE"
-// stanza found on the given cmdline file (defaults to /proc/cmdline when
-// empty). KEY supports dot notation for nested maps, e.g.
+// ParseKairosCmdline builds a Config from every Kairos-owned cmdline
+// stanza found on the given file (defaults to /proc/cmdline when empty).
+// Three token forms are recognised:
 //
-//	kairos.config=config_url=https://example.com/extra.yaml
-//	kairos.config=hostname=box
-//	kairos.config=install.auto=true
+//	kairos.config=KEY=VALUE     — dot+index path, repeatable, last wins
+//	kairos.config_url=URL       — dedicated URL entrypoint (sets config_url)
+//	cos.setup=X                 — legacy: URI routes to config_url,
+//	                              KEY=VALUE behaves as kairos.config
 //
-// List/array indices in the key are not supported. Repeated stanzas are
-// merged; the last value for a given key wins. Returns a Config with an
-// empty Values map when nothing is set so callers can merge it
-// unconditionally. Call MergeConfigURL on the result to recursively pull
-// any remote config referenced through config_url.
+// KEY supports dot notation for nested maps and numeric segments for list
+// indices (e.g. install.auto=true, users.0.name=kairos). Values are
+// stored as strings; downstream schemas coerce as needed. Returns a
+// Config with an empty Values map when nothing is set so callers can
+// merge it unconditionally. Call MergeConfigURL on the result to
+// recursively pull any remote config referenced through config_url.
+// See machine.KairosCmdlineYAML for the underlying syntax details.
 func ParseKairosCmdline(file string) (*Config, error) {
 	result := &Config{Sources: []string{"cmdline"}, Values: ConfigValues{}}
 	y, err := machine.KairosCmdlineYAML(file)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -262,12 +262,6 @@ func Scan(o *Options, filter func(d []byte) ([]byte, error)) (*Config, error) {
 		if err == nil { // best-effort
 			configs = append(configs, cConfig)
 		}
-
-		kConfig, err := ParseKairosCmdline(o.BootCMDLineFile)
-		o.SoftErr("parsing kairos.config cmdline stanzas", err)
-		if err == nil && len(kConfig.Values) > 0 {
-			configs = append(configs, kConfig)
-		}
 	}
 
 	mergedConfig, err := configs.Merge()
@@ -405,61 +399,65 @@ func listFiles(dir string) ([]string, error) {
 	return content, err
 }
 
-// ParseCmdLine reads options from the kernel cmdline and returns the equivalent
-// Config. It treats every KEY=VALUE token on the cmdline as config and relies
-// on the caller-supplied filter to drop non-config kernel args. Tokens using
-// any Kairos-owned prefix (kairos.config=, kairos.config_url=, cos.setup=) are
-// skipped here so they flow exclusively through ParseKairosCmdline, which
-// supports quoted values with spaces, list indices and a dedicated
-// kairos.config_url= URL form.
+// ParseCmdLine reads the kernel cmdline (defaults to /proc/cmdline when
+// file is empty) and returns a single Config that merges two token
+// families in one pass:
+//
+//   - Kairos-owned prefixes (kairos.config=, kairos.config_url=,
+//     cos.setup=) go through machine.KairosCmdlineYAMLFromString, which
+//     supports dot notation with numeric segments for list indices, a
+//     dedicated URL entrypoint (kairos.config_url=URL) and the legacy
+//     cos.setup= alias. Values here bypass the caller-supplied filter
+//     because they have dedicated semantics, not a schema-driven shape.
+//   - Every other KEY=VALUE token is fed to machine.DotStringToYAML
+//     (which skips the Kairos-owned prefixes) and then handed to the
+//     caller-supplied filter so unrelated kernel args are dropped.
+//
+// Both partial YAMLs are unmarshalled and deep-merged; Kairos-owned
+// values win on collision so a kairos.config= stanza cannot be shadowed
+// by a stray generic token with the same key. Call MergeConfigURL on
+// the result to recursively pull any remote config referenced through
+// config_url.
 func ParseCmdLine(file string, filter func(d []byte) ([]byte, error)) (*Config, error) {
-	result := Config{Sources: []string{"cmdline"}}
-	dotToYAML, err := machine.DotToYAML(file)
-	if err != nil {
-		return &result, err
-	}
-
-	filteredYAML, err := filter(dotToYAML)
-	if err != nil {
-		return &result, err
-	}
-
-	err = yaml.Unmarshal(filteredYAML, &result.Values)
-	if err != nil {
-		return &result, err
-	}
-
-	return &result, nil
-}
-
-// ParseKairosCmdline builds a Config from every Kairos-owned cmdline
-// stanza found on the given file (defaults to /proc/cmdline when empty).
-// Three token forms are recognised:
-//
-//	kairos.config=KEY=VALUE     — dot+index path, repeatable, last wins
-//	kairos.config_url=URL       — dedicated URL entrypoint (sets config_url)
-//	cos.setup=X                 — legacy: URI routes to config_url,
-//	                              KEY=VALUE behaves as kairos.config
-//
-// KEY supports dot notation for nested maps and numeric segments for list
-// indices (e.g. install.auto=true, users.0.name=kairos). Values are
-// stored as strings; downstream schemas coerce as needed. Returns a
-// Config with an empty Values map when nothing is set so callers can
-// merge it unconditionally. Call MergeConfigURL on the result to
-// recursively pull any remote config referenced through config_url.
-// See machine.KairosCmdlineYAML for the underlying syntax details.
-func ParseKairosCmdline(file string) (*Config, error) {
 	result := &Config{Sources: []string{"cmdline"}, Values: ConfigValues{}}
-	y, err := machine.KairosCmdlineYAML(file)
+
+	if file == "" {
+		file = "/proc/cmdline"
+	}
+	dat, err := os.ReadFile(file)
 	if err != nil {
 		return result, err
 	}
-	if y == nil {
-		return result, nil
-	}
-	if err := yaml.Unmarshal(y, &result.Values); err != nil {
+	s := string(dat)
+
+	genericYAML, err := machine.DotStringToYAML(s)
+	if err != nil {
 		return result, err
 	}
+	if len(genericYAML) > 0 {
+		filteredYAML, err := filter(genericYAML)
+		if err != nil {
+			return result, err
+		}
+		if err := yaml.Unmarshal(filteredYAML, &result.Values); err != nil {
+			return result, err
+		}
+	}
+
+	kairosYAML, err := machine.KairosCmdlineYAMLFromString(s)
+	if err != nil {
+		return result, err
+	}
+	if len(kairosYAML) > 0 {
+		kairosVals := ConfigValues{}
+		if err := yaml.Unmarshal(kairosYAML, &kairosVals); err != nil {
+			return result, err
+		}
+		if err := result.MergeConfig(&Config{Values: kairosVals}); err != nil {
+			return result, err
+		}
+	}
+
 	return result, nil
 }
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -406,7 +406,12 @@ func listFiles(dir string) ([]string, error) {
 }
 
 // ParseCmdLine reads options from the kernel cmdline and returns the equivalent
-// Config.
+// Config. It treats every KEY=VALUE token on the cmdline as config and relies
+// on the caller-supplied filter to drop non-config kernel args. Tokens using
+// the namespaced kairos.config= and cos.setup= forms are skipped here because
+// they have dedicated parsers (ParseKairosCmdline / machine.CosSetupURI); use
+// those for the namespaced form (no filter required, supports quoted values
+// with spaces).
 func ParseCmdLine(file string, filter func(d []byte) ([]byte, error)) (*Config, error) {
 	result := Config{Sources: []string{"cmdline"}}
 	dotToYAML, err := machine.DotToYAML(file)

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -33,17 +33,39 @@ var _ = Describe("Config Collector", func() {
 		})
 
 		It("builds a Config from kairos.config stanzas with dot notation", func() {
-			path := writeCmdline(`kairos.config=hostname=box kairos.config=config_url=https://example.com/a.yaml kairos.config=install.auto=true`)
+			path := writeCmdline(`kairos.config=hostname=box kairos.config=install.auto=true`)
 			c, err := ParseKairosCmdline(path)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c.Values).To(HaveKeyWithValue("hostname", "box"))
-			Expect(c.Values).To(HaveKeyWithValue("config_url", "https://example.com/a.yaml"))
 			install, ok := c.Values["install"].(ConfigValues)
 			Expect(ok).To(BeTrue())
-			Expect(install).To(HaveKeyWithValue("auto", true))
+			Expect(install).To(HaveKeyWithValue("auto", "true"))
 		})
 
-		It("Scan merges kairos.config stanzas when MergeBootCMDLine is set", func() {
+		It("kairos.config_url is a dedicated URL-only entrypoint that sets config_url verbatim", func() {
+			path := writeCmdline(`kairos.config_url=https://example.com/x.yaml?token=abc=def`)
+			c, err := ParseKairosCmdline(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.Values).To(HaveKeyWithValue("config_url", "https://example.com/x.yaml?token=abc=def"))
+		})
+
+		It("builds nested lists from numeric segments", func() {
+			path := writeCmdline(`kairos.config=users.0.name=kairos kairos.config=users.1.name=foo`)
+			c, err := ParseKairosCmdline(path)
+			Expect(err).ToNot(HaveOccurred())
+			users, ok := c.Values["users"].([]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(users).To(HaveLen(2))
+		})
+
+		It("cos.setup with a bare URI is a legacy alias that populates config_url", func() {
+			path := writeCmdline(`cos.setup=https://example.com/legacy.yaml`)
+			c, err := ParseKairosCmdline(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.Values).To(HaveKeyWithValue("config_url", "https://example.com/legacy.yaml"))
+		})
+
+		It("Scan merges Kairos-owned stanzas when MergeBootCMDLine is set", func() {
 			path := writeCmdline(`kairos.config=hostname=box`)
 			o := &Options{}
 			Expect(o.Apply(MergeBootLine, WithBootCMDLineFile(path), NoLogs)).To(Succeed())
@@ -52,15 +74,16 @@ var _ = Describe("Config Collector", func() {
 			Expect(c.Values).To(HaveKeyWithValue("hostname", "box"))
 		})
 
-		It("Scan does not double-parse kairos.config= / cos.setup= via the generic dot parser", func() {
-			path := writeCmdline(`kairos.config=hostname=box cos.setup=/oem/extra.yaml`)
+		It("Scan does not double-parse kairos.config= / kairos.config_url= / cos.setup= via the generic dot parser", func() {
+			path := writeCmdline(
+				`kairos.config=hostname=box kairos.config_url=https://a/x.yaml cos.setup=/oem/extra.yaml`,
+			)
 			o := &Options{}
 			Expect(o.Apply(MergeBootLine, WithBootCMDLineFile(path), NoLogs)).To(Succeed())
 			c, err := Scan(o, func(d []byte) ([]byte, error) { return d, nil })
 			Expect(err).ToNot(HaveOccurred())
-			// namespaced parser still populates the real key
 			Expect(c.Values).To(HaveKeyWithValue("hostname", "box"))
-			// generic parser must not leak spurious kairos/cos nesting
+			Expect(c.Values).To(HaveKeyWithValue("config_url", "/oem/extra.yaml"))
 			Expect(c.Values).ToNot(HaveKey("kairos"))
 			Expect(c.Values).ToNot(HaveKey("cos"))
 		})

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -15,6 +15,44 @@ import (
 )
 
 var _ = Describe("Config Collector", func() {
+	Describe("ParseKairosCmdline", func() {
+		writeCmdline := func(contents string) string {
+			f, err := os.CreateTemp("", "cmdline")
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = os.Remove(f.Name()) })
+			Expect(os.WriteFile(f.Name(), []byte(contents), 0o644)).To(Succeed())
+			return f.Name()
+		}
+
+		It("returns an empty Config when no stanzas are set", func() {
+			path := writeCmdline("root=LABEL=X rd.immucore.debug\n")
+			c, err := ParseKairosCmdline(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.Values).To(BeEmpty())
+			Expect(c.Sources).To(ConsistOf("cmdline"))
+		})
+
+		It("builds a Config from kairos.config stanzas with dot notation", func() {
+			path := writeCmdline(`kairos.config=hostname=box kairos.config=config_url=https://example.com/a.yaml kairos.config=install.auto=true`)
+			c, err := ParseKairosCmdline(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.Values).To(HaveKeyWithValue("hostname", "box"))
+			Expect(c.Values).To(HaveKeyWithValue("config_url", "https://example.com/a.yaml"))
+			install, ok := c.Values["install"].(ConfigValues)
+			Expect(ok).To(BeTrue())
+			Expect(install).To(HaveKeyWithValue("auto", true))
+		})
+
+		It("Scan merges kairos.config stanzas when MergeBootCMDLine is set", func() {
+			path := writeCmdline(`kairos.config=hostname=box`)
+			o := &Options{}
+			Expect(o.Apply(MergeBootLine, WithBootCMDLineFile(path), NoLogs)).To(Succeed())
+			c, err := Scan(o, func(d []byte) ([]byte, error) { return d, nil })
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.Values).To(HaveKeyWithValue("hostname", "box"))
+		})
+	})
+
 	Describe("Options", func() {
 		var options *Options
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 var _ = Describe("Config Collector", func() {
-	Describe("ParseKairosCmdline", func() {
+	Describe("ParseCmdLine", func() {
 		writeCmdline := func(contents string) string {
 			f, err := os.CreateTemp("", "cmdline")
 			Expect(err).ToNot(HaveOccurred())
@@ -24,17 +24,29 @@ var _ = Describe("Config Collector", func() {
 			return f.Name()
 		}
 
-		It("returns an empty Config when no stanzas are set", func() {
+		passthrough := func(d []byte) ([]byte, error) { return d, nil }
+
+		It("returns an empty Config when no cmdline tokens match", func() {
 			path := writeCmdline("root=LABEL=X rd.immucore.debug\n")
-			c, err := ParseKairosCmdline(path)
+			c, err := ParseCmdLine(path, FilterKeysTestMerge)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c.Values).To(BeEmpty())
 			Expect(c.Sources).To(ConsistOf("cmdline"))
 		})
 
-		It("builds a Config from kairos.config stanzas with dot notation", func() {
+		It("parses generic KEY=VALUE tokens through the filter", func() {
+			path := writeCmdline(`root=X config_url="https://example.com/a.yaml" options.foo=bar`)
+			c, err := ParseCmdLine(path, FilterKeysTest)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.Values).To(HaveKeyWithValue("config_url", "https://example.com/a.yaml"))
+			opts, ok := c.Values["options"].(ConfigValues)
+			Expect(ok).To(BeTrue())
+			Expect(opts).To(HaveKeyWithValue("foo", "bar"))
+		})
+
+		It("parses kairos.config stanzas with dot notation, bypassing the filter", func() {
 			path := writeCmdline(`kairos.config=hostname=box kairos.config=install.auto=true`)
-			c, err := ParseKairosCmdline(path)
+			c, err := ParseCmdLine(path, passthrough)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c.Values).To(HaveKeyWithValue("hostname", "box"))
 			install, ok := c.Values["install"].(ConfigValues)
@@ -44,14 +56,14 @@ var _ = Describe("Config Collector", func() {
 
 		It("kairos.config_url is a dedicated URL-only entrypoint that sets config_url verbatim", func() {
 			path := writeCmdline(`kairos.config_url=https://example.com/x.yaml?token=abc=def`)
-			c, err := ParseKairosCmdline(path)
+			c, err := ParseCmdLine(path, passthrough)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c.Values).To(HaveKeyWithValue("config_url", "https://example.com/x.yaml?token=abc=def"))
 		})
 
 		It("builds nested lists from numeric segments", func() {
 			path := writeCmdline(`kairos.config=users.0.name=kairos kairos.config=users.1.name=foo`)
-			c, err := ParseKairosCmdline(path)
+			c, err := ParseCmdLine(path, passthrough)
 			Expect(err).ToNot(HaveOccurred())
 			users, ok := c.Values["users"].([]interface{})
 			Expect(ok).To(BeTrue())
@@ -60,32 +72,33 @@ var _ = Describe("Config Collector", func() {
 
 		It("cos.setup with a bare URI is a legacy alias that populates config_url", func() {
 			path := writeCmdline(`cos.setup=https://example.com/legacy.yaml`)
-			c, err := ParseKairosCmdline(path)
+			c, err := ParseCmdLine(path, passthrough)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c.Values).To(HaveKeyWithValue("config_url", "https://example.com/legacy.yaml"))
 		})
 
-		It("Scan merges Kairos-owned stanzas when MergeBootCMDLine is set", func() {
+		It("merges Kairos-owned stanzas and generic tokens in one pass", func() {
+			path := writeCmdline(
+				`root=X options.foo=bar kairos.config=hostname=box kairos.config_url=https://a/x.yaml`,
+			)
+			c, err := ParseCmdLine(path, FilterKeysTest)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.Values).To(HaveKeyWithValue("hostname", "box"))
+			Expect(c.Values).To(HaveKeyWithValue("config_url", "https://a/x.yaml"))
+			opts, ok := c.Values["options"].(ConfigValues)
+			Expect(ok).To(BeTrue())
+			Expect(opts).To(HaveKeyWithValue("foo", "bar"))
+			Expect(c.Values).ToNot(HaveKey("kairos"))
+			Expect(c.Values).ToNot(HaveKey("cos"))
+		})
+
+		It("Scan wires ParseCmdLine when MergeBootCMDLine is set", func() {
 			path := writeCmdline(`kairos.config=hostname=box`)
 			o := &Options{}
 			Expect(o.Apply(MergeBootLine, WithBootCMDLineFile(path), NoLogs)).To(Succeed())
-			c, err := Scan(o, func(d []byte) ([]byte, error) { return d, nil })
+			c, err := Scan(o, passthrough)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c.Values).To(HaveKeyWithValue("hostname", "box"))
-		})
-
-		It("Scan does not double-parse kairos.config= / kairos.config_url= / cos.setup= via the generic dot parser", func() {
-			path := writeCmdline(
-				`kairos.config=hostname=box kairos.config_url=https://a/x.yaml cos.setup=/oem/extra.yaml`,
-			)
-			o := &Options{}
-			Expect(o.Apply(MergeBootLine, WithBootCMDLineFile(path), NoLogs)).To(Succeed())
-			c, err := Scan(o, func(d []byte) ([]byte, error) { return d, nil })
-			Expect(err).ToNot(HaveOccurred())
-			Expect(c.Values).To(HaveKeyWithValue("hostname", "box"))
-			Expect(c.Values).To(HaveKeyWithValue("config_url", "/oem/extra.yaml"))
-			Expect(c.Values).ToNot(HaveKey("kairos"))
-			Expect(c.Values).ToNot(HaveKey("cos"))
 		})
 	})
 

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -51,6 +51,19 @@ var _ = Describe("Config Collector", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(c.Values).To(HaveKeyWithValue("hostname", "box"))
 		})
+
+		It("Scan does not double-parse kairos.config= / cos.setup= via the generic dot parser", func() {
+			path := writeCmdline(`kairos.config=hostname=box cos.setup=/oem/extra.yaml`)
+			o := &Options{}
+			Expect(o.Apply(MergeBootLine, WithBootCMDLineFile(path), NoLogs)).To(Succeed())
+			c, err := Scan(o, func(d []byte) ([]byte, error) { return d, nil })
+			Expect(err).ToNot(HaveOccurred())
+			// namespaced parser still populates the real key
+			Expect(c.Values).To(HaveKeyWithValue("hostname", "box"))
+			// generic parser must not leak spurious kairos/cos nesting
+			Expect(c.Values).ToNot(HaveKey("kairos"))
+			Expect(c.Values).ToNot(HaveKey("cos"))
+		})
 	})
 
 	Describe("Options", func() {

--- a/machine/bootcmdline.go
+++ b/machine/bootcmdline.go
@@ -149,6 +149,13 @@ func stringToMap(s string) map[string]interface{} {
 
 	splitted, _ := shlex.Split(s)
 	for _, item := range splitted {
+		// kairos.config= and cos.setup= have dedicated parsers
+		// (KairosCmdlineYAML, CosSetupURI). Skip them here so their
+		// KEY=VALUE payload does not leak into the generic dot-nested
+		// map as a spurious "kairos.config" / "cos.setup" key.
+		if strings.HasPrefix(item, kairosConfigPrefix) || strings.HasPrefix(item, cosSetupPrefix) {
+			continue
+		}
 		parts := strings.SplitN(item, "=", 2)
 		value := "true"
 		if len(parts) > 1 {

--- a/machine/bootcmdline.go
+++ b/machine/bootcmdline.go
@@ -8,6 +8,46 @@ import (
 	"github.com/kairos-io/kairos-sdk/unstructured"
 )
 
+const (
+	kairosConfigPrefix = "kairos.config="
+	cosSetupPrefix     = "cos.setup="
+)
+
+// CosSetupURI returns the URI referenced by the legacy "cos.setup=" cmdline
+// stanza, or an empty string when it is not set. An empty file argument
+// defaults to /proc/cmdline. This stanza points at a yip config source
+// (file, directory or URL) that callers should feed straight to yip.Run
+// so yip fetches and executes it.
+func CosSetupURI(file string) (string, error) {
+	if file == "" {
+		file = "/proc/cmdline"
+	}
+	dat, err := os.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+	return CosSetupURIFromString(string(dat)), nil
+}
+
+// CosSetupURIFromString is the string-based counterpart of CosSetupURI.
+func CosSetupURIFromString(s string) string {
+	tokens, _ := shlex.Split(s)
+	uri := ""
+	for _, t := range tokens {
+		if !strings.HasPrefix(t, cosSetupPrefix) {
+			continue
+		}
+		v := strings.TrimPrefix(t, cosSetupPrefix)
+		if v == "" {
+			continue
+		}
+		// last occurrence wins, matching how repeated cmdline flags
+		// behave in the rest of the codebase.
+		uri = strings.Trim(v, `"`)
+	}
+	return uri
+}
+
 func DotToYAML(file string) ([]byte, error) {
 	if file == "" {
 		file = "/proc/cmdline"
@@ -19,6 +59,88 @@ func DotToYAML(file string) ([]byte, error) {
 
 	v := stringToMap(string(dat))
 
+	return unstructured.ToYAML(v)
+}
+
+// DotStringToYAML turns a whitespace-separated set of KEY=VALUE tokens (with
+// KEY supporting dot notation) into a YAML document. It is the string-based
+// counterpart of DotToYAML.
+func DotStringToYAML(s string) ([]byte, error) {
+	return unstructured.ToYAML(stringToMap(s))
+}
+
+// KairosConfigStanzas returns the value part of every "kairos.config=" stanza
+// found in the given cmdline file. The "kairos.config=" prefix is stripped so
+// callers get the raw KEY=VALUE payload. An empty file argument defaults to
+// /proc/cmdline. Stanzas whose payload is empty are dropped.
+func KairosConfigStanzas(file string) ([]string, error) {
+	if file == "" {
+		file = "/proc/cmdline"
+	}
+	dat, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return KairosConfigStanzasFromString(string(dat)), nil
+}
+
+// KairosConfigStanzasFromString is the string-based counterpart of
+// KairosConfigStanzas.
+func KairosConfigStanzasFromString(s string) []string {
+	tokens, _ := shlex.Split(s)
+	var out []string
+	for _, t := range tokens {
+		if !strings.HasPrefix(t, kairosConfigPrefix) {
+			continue
+		}
+		v := strings.TrimPrefix(t, kairosConfigPrefix)
+		if v == "" {
+			continue
+		}
+		out = append(out, v)
+	}
+	return out
+}
+
+// KairosCmdlineYAML builds a YAML document out of every "kairos.config=KEY=VALUE"
+// stanza on the cmdline. KEY supports dot notation for nested maps, so
+//
+//	kairos.config=install.auto=true kairos.config=hostname=box
+//
+// yields nested YAML with both install.auto and hostname set. List/array
+// indices in the key (e.g. foo.0.bar) are not supported by the underlying
+// dot-to-yaml pipeline. Repeated occurrences are merged and the last value
+// for a given key wins. Values may contain spaces if the whole stanza is
+// quoted on the kernel command line (e.g. kairos.config="hostname=my box").
+// Returns (nil, nil) when no stanzas are present so callers can skip cheaply.
+func KairosCmdlineYAML(file string) ([]byte, error) {
+	stanzas, err := KairosConfigStanzas(file)
+	if err != nil {
+		return nil, err
+	}
+	return kairosCmdlineYAMLFromStanzas(stanzas)
+}
+
+// KairosCmdlineYAMLFromString is the string-based counterpart of KairosCmdlineYAML.
+// It is useful when the cmdline has already been read from a mock filesystem.
+func KairosCmdlineYAMLFromString(s string) ([]byte, error) {
+	return kairosCmdlineYAMLFromStanzas(KairosConfigStanzasFromString(s))
+}
+
+func kairosCmdlineYAMLFromStanzas(stanzas []string) ([]byte, error) {
+	if len(stanzas) == 0 {
+		return nil, nil
+	}
+	v := map[string]interface{}{}
+	for _, entry := range stanzas {
+		parts := strings.SplitN(entry, "=", 2)
+		value := "true"
+		if len(parts) > 1 {
+			value = strings.Trim(parts[1], `"`)
+		}
+		key := strings.Trim(parts[0], `"`)
+		v[key] = value
+	}
 	return unstructured.ToYAML(v)
 }
 

--- a/machine/bootcmdline.go
+++ b/machine/bootcmdline.go
@@ -100,10 +100,13 @@ func KairosCmdlineYAMLFromString(s string) ([]byte, error) {
 	return yaml.Marshal(root)
 }
 
-// DotToYAML preserves the pre-existing generic dot-nested cmdline parser
-// used by collector.ParseCmdLine. It intentionally skips every
-// Kairos-owned prefix (see KairosOwnedPrefixes) so those tokens flow
-// exclusively through KairosCmdlineYAML.
+// DotToYAML is the generic dot-nested cmdline parser: every KEY=VALUE
+// token on the given file (defaults to /proc/cmdline when empty)
+// becomes a YAML entry, with dots in KEY producing nested maps.
+// Kairos-owned prefixes (see KairosOwnedPrefixes) are intentionally
+// skipped so those tokens flow exclusively through KairosCmdlineYAML.
+// Callers wanting both families merged should use
+// collector.ParseCmdLine, which routes each token to the right parser.
 func DotToYAML(file string) ([]byte, error) {
 	if file == "" {
 		file = "/proc/cmdline"

--- a/machine/bootcmdline.go
+++ b/machine/bootcmdline.go
@@ -2,52 +2,108 @@ package machine
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/google/shlex"
 	"github.com/kairos-io/kairos-sdk/unstructured"
+	"gopkg.in/yaml.v3"
 )
 
+// Cmdline stanzas owned exclusively by this package. ParseCmdLine and any
+// other generic dot-parser must skip these so their payload is not double
+// processed and does not leak spurious kairos/cos top-level keys.
 const (
-	kairosConfigPrefix = "kairos.config="
-	cosSetupPrefix     = "cos.setup="
+	kairosConfigPrefix    = "kairos.config="
+	kairosConfigURLPrefix = "kairos.config_url="
+	cosSetupPrefix        = "cos.setup="
 )
 
-// CosSetupURI returns the URI referenced by the legacy "cos.setup=" cmdline
-// stanza, or an empty string when it is not set. An empty file argument
-// defaults to /proc/cmdline. This stanza points at a yip config source
-// (file, directory or URL) that callers should feed straight to yip.Run
-// so yip fetches and executes it.
-func CosSetupURI(file string) (string, error) {
+// KairosOwnedPrefixes lists the cmdline token prefixes this package owns.
+// Callers implementing their own cmdline parsing (e.g. the generic
+// dot-nested parser in collector.ParseCmdLine) must skip any token that
+// starts with one of these so the payload is not double-parsed.
+var KairosOwnedPrefixes = []string{kairosConfigPrefix, kairosConfigURLPrefix, cosSetupPrefix}
+
+// KairosCmdlineYAML builds a YAML document from every Kairos-owned cmdline
+// stanza on the given file (defaults to /proc/cmdline when empty).
+//
+// Three token forms are recognised, all handled by this single entrypoint:
+//
+//   - kairos.config=KEY=VALUE — sets KEY to VALUE. KEY supports dot notation
+//     for nested maps (e.g. install.auto=true) and numeric segments for list
+//     indices (e.g. users.0.name=kairos). Repeatable; later occurrences of
+//     the same key win. Values may contain spaces if the whole token is
+//     quoted (e.g. kairos.config="hostname=my box"). All values are stored
+//     as strings; downstream schemas coerce as needed.
+//   - kairos.config_url=URL — convenience form that sets the top-level
+//     config_url key. URL is stored verbatim (no KEY=VALUE parsing) so it
+//     can contain '=' safely.
+//   - cos.setup=X — legacy alias, kept so existing installs keep booting.
+//     If X contains '=' it is treated exactly like kairos.config=X;
+//     otherwise the bare value is routed into config_url (matching the
+//     historical "cos.setup points at a config" behavior). Prefer
+//     kairos.config / kairos.config_url in new deployments.
+//
+// Returns (nil, nil) when no Kairos-owned stanzas are present so callers
+// can skip cheaply.
+func KairosCmdlineYAML(file string) ([]byte, error) {
 	if file == "" {
 		file = "/proc/cmdline"
 	}
 	dat, err := os.ReadFile(file)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return CosSetupURIFromString(string(dat)), nil
+	return KairosCmdlineYAMLFromString(string(dat))
 }
 
-// CosSetupURIFromString is the string-based counterpart of CosSetupURI.
-func CosSetupURIFromString(s string) string {
+// KairosCmdlineYAMLFromString is the string-based counterpart of
+// KairosCmdlineYAML. Useful for tests and for callers that have already
+// read the cmdline from a mock filesystem.
+func KairosCmdlineYAMLFromString(s string) ([]byte, error) {
 	tokens, _ := shlex.Split(s)
-	uri := ""
+	root := map[string]interface{}{}
+	present := false
 	for _, t := range tokens {
-		if !strings.HasPrefix(t, cosSetupPrefix) {
-			continue
+		switch {
+		case strings.HasPrefix(t, kairosConfigURLPrefix):
+			v := strings.Trim(strings.TrimPrefix(t, kairosConfigURLPrefix), `"`)
+			if v == "" {
+				continue
+			}
+			root["config_url"] = v
+			present = true
+		case strings.HasPrefix(t, kairosConfigPrefix):
+			payload := strings.TrimPrefix(t, kairosConfigPrefix)
+			if payload == "" {
+				continue
+			}
+			applyKairosConfigStanza(root, payload)
+			present = true
+		case strings.HasPrefix(t, cosSetupPrefix):
+			payload := strings.TrimPrefix(t, cosSetupPrefix)
+			if payload == "" {
+				continue
+			}
+			if strings.Contains(payload, "=") {
+				applyKairosConfigStanza(root, payload)
+			} else {
+				root["config_url"] = strings.Trim(payload, `"`)
+			}
+			present = true
 		}
-		v := strings.TrimPrefix(t, cosSetupPrefix)
-		if v == "" {
-			continue
-		}
-		// last occurrence wins, matching how repeated cmdline flags
-		// behave in the rest of the codebase.
-		uri = strings.Trim(v, `"`)
 	}
-	return uri
+	if !present {
+		return nil, nil
+	}
+	return yaml.Marshal(root)
 }
 
+// DotToYAML preserves the pre-existing generic dot-nested cmdline parser
+// used by collector.ParseCmdLine. It intentionally skips every
+// Kairos-owned prefix (see KairosOwnedPrefixes) so those tokens flow
+// exclusively through KairosCmdlineYAML.
 func DotToYAML(file string) ([]byte, error) {
 	if file == "" {
 		file = "/proc/cmdline"
@@ -56,104 +112,74 @@ func DotToYAML(file string) ([]byte, error) {
 	if err != nil {
 		return []byte{}, err
 	}
-
-	v := stringToMap(string(dat))
-
-	return unstructured.ToYAML(v)
+	return unstructured.ToYAML(stringToMap(string(dat)))
 }
 
-// DotStringToYAML turns a whitespace-separated set of KEY=VALUE tokens (with
-// KEY supporting dot notation) into a YAML document. It is the string-based
-// counterpart of DotToYAML.
+// DotStringToYAML is the string-based counterpart of DotToYAML.
 func DotStringToYAML(s string) ([]byte, error) {
 	return unstructured.ToYAML(stringToMap(s))
 }
 
-// KairosConfigStanzas returns the value part of every "kairos.config=" stanza
-// found in the given cmdline file. The "kairos.config=" prefix is stripped so
-// callers get the raw KEY=VALUE payload. An empty file argument defaults to
-// /proc/cmdline. Stanzas whose payload is empty are dropped.
-func KairosConfigStanzas(file string) ([]string, error) {
-	if file == "" {
-		file = "/proc/cmdline"
+// applyKairosConfigStanza parses a "KEY=VALUE" payload (KEY may use
+// dot notation with numeric segments for list indices) and writes it into
+// root. Payloads without '=' set the key to the literal string "true", so
+// bare-flag stanzas like kairos.config=install.auto behave sensibly.
+func applyKairosConfigStanza(root map[string]interface{}, payload string) {
+	parts := strings.SplitN(payload, "=", 2)
+	value := "true"
+	if len(parts) > 1 {
+		value = strings.Trim(parts[1], `"`)
 	}
-	dat, err := os.ReadFile(file)
-	if err != nil {
-		return nil, err
+	key := strings.Trim(parts[0], `"`)
+	if key == "" {
+		return
 	}
-	return KairosConfigStanzasFromString(string(dat)), nil
+	segs := strings.Split(key, ".")
+	// The root is always a map keyed by the first segment (numeric first
+	// segments are treated as string keys, since the top level is a map).
+	first := segs[0]
+	root[first] = setDotIndexPath(root[first], segs[1:], value)
 }
 
-// KairosConfigStanzasFromString is the string-based counterpart of
-// KairosConfigStanzas.
-func KairosConfigStanzasFromString(s string) []string {
-	tokens, _ := shlex.Split(s)
-	var out []string
-	for _, t := range tokens {
-		if !strings.HasPrefix(t, kairosConfigPrefix) {
-			continue
+// setDotIndexPath writes value at the given path into node, creating
+// nested maps for non-numeric segments and slices for numeric segments.
+// The node argument may be nil, a map[string]interface{}, or a
+// []interface{}. Returns the possibly-replaced node so callers can
+// re-assign into their parent container.
+func setDotIndexPath(node interface{}, segs []string, value interface{}) interface{} {
+	if len(segs) == 0 {
+		return value
+	}
+	seg := segs[0]
+	rest := segs[1:]
+	if idx, err := strconv.Atoi(seg); err == nil && idx >= 0 {
+		var list []interface{}
+		if l, ok := node.([]interface{}); ok {
+			list = l
 		}
-		v := strings.TrimPrefix(t, kairosConfigPrefix)
-		if v == "" {
-			continue
+		for len(list) <= idx {
+			list = append(list, nil)
 		}
-		out = append(out, v)
+		list[idx] = setDotIndexPath(list[idx], rest, value)
+		return list
 	}
-	return out
+	m, ok := node.(map[string]interface{})
+	if !ok {
+		m = map[string]interface{}{}
+	}
+	m[seg] = setDotIndexPath(m[seg], rest, value)
+	return m
 }
 
-// KairosCmdlineYAML builds a YAML document out of every "kairos.config=KEY=VALUE"
-// stanza on the cmdline. KEY supports dot notation for nested maps, so
-//
-//	kairos.config=install.auto=true kairos.config=hostname=box
-//
-// yields nested YAML with both install.auto and hostname set. List/array
-// indices in the key (e.g. foo.0.bar) are not supported by the underlying
-// dot-to-yaml pipeline. Repeated occurrences are merged and the last value
-// for a given key wins. Values may contain spaces if the whole stanza is
-// quoted on the kernel command line (e.g. kairos.config="hostname=my box").
-// Returns (nil, nil) when no stanzas are present so callers can skip cheaply.
-func KairosCmdlineYAML(file string) ([]byte, error) {
-	stanzas, err := KairosConfigStanzas(file)
-	if err != nil {
-		return nil, err
-	}
-	return kairosCmdlineYAMLFromStanzas(stanzas)
-}
-
-// KairosCmdlineYAMLFromString is the string-based counterpart of KairosCmdlineYAML.
-// It is useful when the cmdline has already been read from a mock filesystem.
-func KairosCmdlineYAMLFromString(s string) ([]byte, error) {
-	return kairosCmdlineYAMLFromStanzas(KairosConfigStanzasFromString(s))
-}
-
-func kairosCmdlineYAMLFromStanzas(stanzas []string) ([]byte, error) {
-	if len(stanzas) == 0 {
-		return nil, nil
-	}
-	v := map[string]interface{}{}
-	for _, entry := range stanzas {
-		parts := strings.SplitN(entry, "=", 2)
-		value := "true"
-		if len(parts) > 1 {
-			value = strings.Trim(parts[1], `"`)
-		}
-		key := strings.Trim(parts[0], `"`)
-		v[key] = value
-	}
-	return unstructured.ToYAML(v)
-}
-
+// stringToMap is the generic dot-nested KEY=VALUE parser used by
+// DotToYAML / DotStringToYAML. It skips every Kairos-owned prefix so
+// those tokens are handled exclusively by KairosCmdlineYAML.
 func stringToMap(s string) map[string]interface{} {
 	v := map[string]interface{}{}
 
 	splitted, _ := shlex.Split(s)
 	for _, item := range splitted {
-		// kairos.config= and cos.setup= have dedicated parsers
-		// (KairosCmdlineYAML, CosSetupURI). Skip them here so their
-		// KEY=VALUE payload does not leak into the generic dot-nested
-		// map as a spurious "kairos.config" / "cos.setup" key.
-		if strings.HasPrefix(item, kairosConfigPrefix) || strings.HasPrefix(item, cosSetupPrefix) {
+		if isKairosOwned(item) {
 			continue
 		}
 		parts := strings.SplitN(item, "=", 2)
@@ -166,4 +192,13 @@ func stringToMap(s string) map[string]interface{} {
 	}
 
 	return v
+}
+
+func isKairosOwned(token string) bool {
+	for _, p := range KairosOwnedPrefixes {
+		if strings.HasPrefix(token, p) {
+			return true
+		}
+	}
+	return false
 }

--- a/machine/bootcmdline_test.go
+++ b/machine/bootcmdline_test.go
@@ -110,6 +110,25 @@ var _ = Describe("BootCMDLine", func() {
 
 			Expect(string(b)).To(Equal("baz:\n    bar: \"\"\nconfig_url: foo bar\n"), string(b))
 		})
+		It("skips kairos.config= and cos.setup= tokens so their payload does not leak", func() {
+			f, err := os.CreateTemp("", "test")
+			Expect(err).ToNot(HaveOccurred())
+			defer os.RemoveAll(f.Name())
+
+			err = os.WriteFile(f.Name(),
+				[]byte(`root=LABEL=X kairos.config=hostname=box cos.setup=/oem/50-extra.yaml foo=bar`),
+				os.ModePerm)
+			Expect(err).ToNot(HaveOccurred())
+
+			b, err := DotToYAML(f.Name())
+			Expect(err).ToNot(HaveOccurred())
+			out := string(b)
+			Expect(out).ToNot(ContainSubstring("kairos:"))
+			Expect(out).ToNot(ContainSubstring("cos:"))
+			Expect(out).ToNot(ContainSubstring("hostname=box"))
+			Expect(out).ToNot(ContainSubstring("50-extra.yaml"))
+			Expect(out).To(ContainSubstring("foo: bar"))
+		})
 		It("works if cmdline contains a dash or underscore", func() {
 			f, err := os.CreateTemp("", "test")
 			Expect(err).ToNot(HaveOccurred())

--- a/machine/bootcmdline_test.go
+++ b/machine/bootcmdline_test.go
@@ -9,6 +9,92 @@ import (
 )
 
 var _ = Describe("BootCMDLine", func() {
+	Context("kairos.config stanzas", func() {
+		writeCmdline := func(contents string) string {
+			f, err := os.CreateTemp("", "cmdline")
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = os.Remove(f.Name()) })
+			Expect(os.WriteFile(f.Name(), []byte(contents), 0o644)).To(Succeed())
+			return f.Name()
+		}
+
+		It("returns nothing when no stanzas are present", func() {
+			path := writeCmdline("root=LABEL=X rd.immucore.debug\n")
+			stanzas, err := KairosConfigStanzas(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stanzas).To(BeEmpty())
+
+			y, err := KairosCmdlineYAML(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(y).To(BeNil())
+		})
+
+		It("extracts a single stanza", func() {
+			path := writeCmdline("root=X kairos.config=config_url=https://example.com/a.yaml\n")
+			stanzas, err := KairosConfigStanzas(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stanzas).To(ConsistOf("config_url=https://example.com/a.yaml"))
+		})
+
+		It("collects multiple stanzas and builds nested YAML", func() {
+			path := writeCmdline(`kairos.config=hostname=box kairos.config=config_url=https://example.com/a.yaml kairos.config=install.auto=true`)
+			y, err := KairosCmdlineYAML(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(y)).To(ContainSubstring("hostname: box"))
+			Expect(string(y)).To(ContainSubstring("config_url: https://example.com/a.yaml"))
+			Expect(string(y)).To(ContainSubstring("install:"))
+			Expect(string(y)).To(ContainSubstring("auto: true"))
+		})
+
+		It("supports quoted values with spaces", func() {
+			path := writeCmdline(`kairos.config=hostname="my box"`)
+			y, err := KairosCmdlineYAML(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(y)).To(ContainSubstring("hostname: my box"))
+		})
+
+		It("drops empty payloads", func() {
+			path := writeCmdline(`kairos.config= kairos.config=hostname=box`)
+			stanzas, err := KairosConfigStanzas(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stanzas).To(ConsistOf("hostname=box"))
+		})
+	})
+
+	Context("cos.setup stanza", func() {
+		writeCmdline := func(contents string) string {
+			f, err := os.CreateTemp("", "cmdline")
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = os.Remove(f.Name()) })
+			Expect(os.WriteFile(f.Name(), []byte(contents), 0o644)).To(Succeed())
+			return f.Name()
+		}
+
+		It("returns empty when not set", func() {
+			path := writeCmdline("root=LABEL=X rd.immucore.debug\n")
+			uri, err := CosSetupURI(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(uri).To(BeEmpty())
+		})
+
+		It("extracts a URL value", func() {
+			path := writeCmdline("root=X cos.setup=https://example.com/legacy.yaml\n")
+			uri, err := CosSetupURI(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(uri).To(Equal("https://example.com/legacy.yaml"))
+		})
+
+		It("extracts a file path value", func() {
+			uri := CosSetupURIFromString(`cos.setup=/oem/50-extra.yaml`)
+			Expect(uri).To(Equal("/oem/50-extra.yaml"))
+		})
+
+		It("drops empty payloads and lets the last occurrence win", func() {
+			uri := CosSetupURIFromString(`cos.setup= cos.setup=https://example.com/a.yaml cos.setup=https://example.com/b.yaml`)
+			Expect(uri).To(Equal("https://example.com/b.yaml"))
+		})
+	})
+
 	Context("parses data", func() {
 
 		It("returns cmdline if provided", func() {

--- a/machine/bootcmdline_test.go
+++ b/machine/bootcmdline_test.go
@@ -9,118 +9,123 @@ import (
 )
 
 var _ = Describe("BootCMDLine", func() {
-	Context("kairos.config stanzas", func() {
-		writeCmdline := func(contents string) string {
-			f, err := os.CreateTemp("", "cmdline")
-			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() { _ = os.Remove(f.Name()) })
-			Expect(os.WriteFile(f.Name(), []byte(contents), 0o644)).To(Succeed())
-			return f.Name()
-		}
+	writeCmdline := func(contents string) string {
+		f, err := os.CreateTemp("", "cmdline")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() { _ = os.Remove(f.Name()) })
+		Expect(os.WriteFile(f.Name(), []byte(contents), 0o644)).To(Succeed())
+		return f.Name()
+	}
 
-		It("returns nothing when no stanzas are present", func() {
+	Context("KairosCmdlineYAML", func() {
+		It("returns nil when no owned stanzas are present", func() {
 			path := writeCmdline("root=LABEL=X rd.immucore.debug\n")
-			stanzas, err := KairosConfigStanzas(path)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stanzas).To(BeEmpty())
-
 			y, err := KairosCmdlineYAML(path)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(y).To(BeNil())
 		})
 
-		It("extracts a single stanza", func() {
-			path := writeCmdline("root=X kairos.config=config_url=https://example.com/a.yaml\n")
-			stanzas, err := KairosConfigStanzas(path)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(stanzas).To(ConsistOf("config_url=https://example.com/a.yaml"))
-		})
-
-		It("collects multiple stanzas and builds nested YAML", func() {
-			path := writeCmdline(`kairos.config=hostname=box kairos.config=config_url=https://example.com/a.yaml kairos.config=install.auto=true`)
-			y, err := KairosCmdlineYAML(path)
+		It("parses a single kairos.config stanza", func() {
+			y, err := KairosCmdlineYAMLFromString(`root=X kairos.config=hostname=box`)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(y)).To(ContainSubstring("hostname: box"))
-			Expect(string(y)).To(ContainSubstring("config_url: https://example.com/a.yaml"))
+		})
+
+		It("builds nested maps from dot notation", func() {
+			y, err := KairosCmdlineYAMLFromString(
+				`kairos.config=install.auto=true kairos.config=install.reboot=false`,
+			)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(string(y)).To(ContainSubstring("install:"))
-			Expect(string(y)).To(ContainSubstring("auto: true"))
+			Expect(string(y)).To(ContainSubstring("auto: \"true\""))
+			Expect(string(y)).To(ContainSubstring("reboot: \"false\""))
+		})
+
+		It("builds lists from numeric segments", func() {
+			y, err := KairosCmdlineYAMLFromString(
+				`kairos.config=users.0.name=kairos kairos.config=users.0.passwd=k kairos.config=users.1.name=foo`,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(y)).To(ContainSubstring("users:"))
+			Expect(string(y)).To(ContainSubstring("- name: kairos"))
+			Expect(string(y)).To(ContainSubstring("passwd: k"))
+			Expect(string(y)).To(ContainSubstring("- name: foo"))
 		})
 
 		It("supports quoted values with spaces", func() {
-			path := writeCmdline(`kairos.config=hostname="my box"`)
-			y, err := KairosCmdlineYAML(path)
+			y, err := KairosCmdlineYAMLFromString(`kairos.config=hostname="my box"`)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(y)).To(ContainSubstring("hostname: my box"))
 		})
 
 		It("drops empty payloads", func() {
-			path := writeCmdline(`kairos.config= kairos.config=hostname=box`)
-			stanzas, err := KairosConfigStanzas(path)
+			y, err := KairosCmdlineYAMLFromString(`kairos.config= kairos.config=hostname=box`)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(stanzas).To(ConsistOf("hostname=box"))
+			Expect(string(y)).To(ContainSubstring("hostname: box"))
+			Expect(string(y)).ToNot(ContainSubstring("kairos"))
+		})
+
+		It("kairos.config_url sets top-level config_url and keeps '=' in the URL intact", func() {
+			y, err := KairosCmdlineYAMLFromString(
+				`kairos.config_url=https://example.com/x.yaml?token=abc=def`,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(y)).To(ContainSubstring("config_url: https://example.com/x.yaml?token=abc=def"))
+		})
+
+		It("cos.setup with a bare URI routes into config_url (legacy)", func() {
+			y, err := KairosCmdlineYAMLFromString(`cos.setup=https://example.com/legacy.yaml`)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(y)).To(ContainSubstring("config_url: https://example.com/legacy.yaml"))
+		})
+
+		It("cos.setup with KEY=VALUE behaves like kairos.config (legacy)", func() {
+			y, err := KairosCmdlineYAMLFromString(`cos.setup=hostname=box`)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(y)).To(ContainSubstring("hostname: box"))
+		})
+
+		It("merges all three prefixes into one document", func() {
+			y, err := KairosCmdlineYAMLFromString(
+				`kairos.config=hostname=box kairos.config_url=https://a/x.yaml cos.setup=install.auto=true`,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			out := string(y)
+			Expect(out).To(ContainSubstring("hostname: box"))
+			Expect(out).To(ContainSubstring("config_url: https://a/x.yaml"))
+			Expect(out).To(ContainSubstring("install:"))
+			Expect(out).To(ContainSubstring("auto: \"true\""))
+		})
+
+		It("later occurrences of the same key win", func() {
+			y, err := KairosCmdlineYAMLFromString(
+				`kairos.config=hostname=a kairos.config=hostname=b`,
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(y)).To(ContainSubstring("hostname: b"))
+			Expect(string(y)).ToNot(ContainSubstring("hostname: a"))
 		})
 	})
 
-	Context("cos.setup stanza", func() {
-		writeCmdline := func(contents string) string {
-			f, err := os.CreateTemp("", "cmdline")
+	Context("DotToYAML", func() {
+		It("parses generic KEY=VALUE cmdline into nested YAML", func() {
+			path := writeCmdline(`config_url="foo bar" baz.bar=""`)
+			b, err := DotToYAML(path)
 			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(func() { _ = os.Remove(f.Name()) })
-			Expect(os.WriteFile(f.Name(), []byte(contents), 0o644)).To(Succeed())
-			return f.Name()
-		}
-
-		It("returns empty when not set", func() {
-			path := writeCmdline("root=LABEL=X rd.immucore.debug\n")
-			uri, err := CosSetupURI(path)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(uri).To(BeEmpty())
-		})
-
-		It("extracts a URL value", func() {
-			path := writeCmdline("root=X cos.setup=https://example.com/legacy.yaml\n")
-			uri, err := CosSetupURI(path)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(uri).To(Equal("https://example.com/legacy.yaml"))
-		})
-
-		It("extracts a file path value", func() {
-			uri := CosSetupURIFromString(`cos.setup=/oem/50-extra.yaml`)
-			Expect(uri).To(Equal("/oem/50-extra.yaml"))
-		})
-
-		It("drops empty payloads and lets the last occurrence win", func() {
-			uri := CosSetupURIFromString(`cos.setup= cos.setup=https://example.com/a.yaml cos.setup=https://example.com/b.yaml`)
-			Expect(uri).To(Equal("https://example.com/b.yaml"))
-		})
-	})
-
-	Context("parses data", func() {
-
-		It("returns cmdline if provided", func() {
-			f, err := os.CreateTemp("", "test")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(f.Name())
-
-			err = os.WriteFile(f.Name(), []byte(`config_url="foo bar" baz.bar=""`), os.ModePerm)
-			Expect(err).ToNot(HaveOccurred())
-
-			b, err := DotToYAML(f.Name())
-			Expect(err).ToNot(HaveOccurred())
-
 			Expect(string(b)).To(Equal("baz:\n    bar: \"\"\nconfig_url: foo bar\n"), string(b))
 		})
-		It("skips kairos.config= and cos.setup= tokens so their payload does not leak", func() {
-			f, err := os.CreateTemp("", "test")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(f.Name())
 
-			err = os.WriteFile(f.Name(),
-				[]byte(`root=LABEL=X kairos.config=hostname=box cos.setup=/oem/50-extra.yaml foo=bar`),
-				os.ModePerm)
+		It("works if cmdline contains a dash or underscore", func() {
+			path := writeCmdline(`config-url="foo bar" ba_z.bar=""`)
+			_, err := DotToYAML(path)
 			Expect(err).ToNot(HaveOccurred())
+		})
 
-			b, err := DotToYAML(f.Name())
+		It("skips every Kairos-owned prefix so payload does not leak", func() {
+			path := writeCmdline(
+				`root=LABEL=X kairos.config=hostname=box kairos.config_url=https://a/x.yaml cos.setup=/oem/50-extra.yaml foo=bar`,
+			)
+			b, err := DotToYAML(path)
 			Expect(err).ToNot(HaveOccurred())
 			out := string(b)
 			Expect(out).ToNot(ContainSubstring("kairos:"))
@@ -128,17 +133,6 @@ var _ = Describe("BootCMDLine", func() {
 			Expect(out).ToNot(ContainSubstring("hostname=box"))
 			Expect(out).ToNot(ContainSubstring("50-extra.yaml"))
 			Expect(out).To(ContainSubstring("foo: bar"))
-		})
-		It("works if cmdline contains a dash or underscore", func() {
-			f, err := os.CreateTemp("", "test")
-			Expect(err).ToNot(HaveOccurred())
-			defer os.RemoveAll(f.Name())
-
-			err = os.WriteFile(f.Name(), []byte(`config-url="foo bar" ba_z.bar=""`), os.ModePerm)
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = DotToYAML(f.Name())
-			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
Both immucore and kairos-agent were scraping the kernel cmdline for Kairos config with their own parsers. The immucore side was broken, the agent side worked but was buried in agent code. Move the parsing into the SDK so both consumers share one implementation.

Three cmdline prefixes are owned by Kairos and parsed here:

- `kairos.config=KEY=VALUE` — repeatable. Each occurrence sets a config key, KEY accepts dot notation for nested maps and now numeric segments for list indices (e.g. `kairos.config=install.auto=true`, `kairos.config=users.0.name=kairos`). Multiple stanzas merge into a single YAML document callers can hand to yip. VALUE can be quoted so it may contain spaces.
- `kairos.config_url=URL` — new, dedicated URL-only entrypoint. Writes top-level `config_url` verbatim, so `=` inside the URL (query strings, tokens) is safe.
- `cos.setup=X` — legacy alias, kept because we cannot drop legacy entrypoints cleanly. A bare URI routes to `config_url`; a `KEY=VALUE` payload behaves the same as `kairos.config=`.

The API collapses to a single entry point: `machine.KairosCmdlineYAML` (and `KairosCmdlineYAMLFromString`). The old split helpers (`CosSetupURI*`, `KairosConfigStanzas*`) are gone. `machine.KairosOwnedPrefixes` is exported so external cmdline parsers can skip the same tokens instead of re-deriving the list, and `stringToMap` in `machine/bootcmdline.go` (used by `DotToYAML`) uses it to make sure nothing else re-parses our prefixes as generic dot-notation keys.

`collector.ParseKairosCmdline(*Config)` keeps the same signature and is wired into `Scan()` when `MergeBootCMDLine` is set, so existing callers pick it up transparently. Tests cover empty, quoted, multiple, dot-notation and list-index stanzas across all three prefixes, plus a `Scan` integration test.

Companion branches with the same name (`feat/kairos-config-cmdline`) exist in immucore and kairos-agent and will switch to these helpers once this merges.

Partially fixes kairos-io/kairos#3809 — this covers the cmdline half of `config_url`.