### PR TITLE
fix(schema): validate stage command lists

### DIFF
--- a/schema/root_schema.go
+++ b/schema/root_schema.go
@@ -17,23 +17,30 @@ type RootSchema struct {
 	Env                       []string       `json:"env,omitempty"`
 	FailOnBundleErrors        bool           `json:"fail_on_bundles_errors,omitempty"`
 	GrubOptionsSchema         `json:"grub_options,omitempty"`
-	Install                   InstallSchema  `json:"install,omitempty"`
-	Options                   []interface{}  `json:"options,omitempty" description:"Various options."`
-	Users                     []UserSchema   `json:"users,omitempty" minItems:"1" required:"true"`
-	P2P                       P2PSchema      `json:"p2p,omitempty"`
-	Debug                     bool           `json:"debug,omitempty" mapstructure:"debug"`
-	Strict                    bool           `json:"strict,omitempty" mapstructure:"strict"`
-	CloudInitPaths            []string       `json:"cloud-init-paths,omitempty" mapstructure:"cloud-init-paths"`
-	EjectCD                   bool           `json:"eject-cd,omitempty" mapstructure:"eject-cd"`
-	FullCloudConfig           string         `json:"fullcloudconfig,omitempty" mapstructure:"fullcloudconfig"`
-	Cosign                    bool           `json:"cosign,omitempty" mapstructure:"cosign"`
-	Verify                    bool           `json:"verify,omitempty" mapstructure:"verify"`
-	CosignPubKey              string         `json:"cosign-key,omitempty" mapstructure:"cosign-key"`
-	Arch                      string         `json:"arch,omitempty" mapstructure:"arch"`
-	Platform                  PlatformSchema `json:"platform,omitempty" mapstructure:"platform"`
-	SquashFsCompressionConfig []string       `json:"squash-compression,omitempty" mapstructure:"squash-compression"`
-	SquashFsNoCompression     bool           `json:"squash-no-compression,omitempty" mapstructure:"squash-no-compression"`
-	UkiMaxEntries             int            `json:"uki-max-entries,omitempty" mapstructure:"uki-max-entries"`
+	Install                   InstallSchema            `json:"install,omitempty"`
+	Options                   []interface{}            `json:"options,omitempty" description:"Various options."`
+	Users                     []UserSchema             `json:"users,omitempty" minItems:"1" required:"true"`
+	P2P                       P2PSchema                `json:"p2p,omitempty"`
+	Debug                     bool                     `json:"debug,omitempty" mapstructure:"debug"`
+	Strict                    bool                     `json:"strict,omitempty" mapstructure:"strict"`
+	CloudInitPaths            []string                 `json:"cloud-init-paths,omitempty" mapstructure:"cloud-init-paths"`
+	EjectCD                   bool                     `json:"eject-cd,omitempty" mapstructure:"eject-cd"`
+	FullCloudConfig           string                   `json:"fullcloudconfig,omitempty" mapstructure:"fullcloudconfig"`
+	Cosign                    bool                     `json:"cosign,omitempty" mapstructure:"cosign"`
+	Verify                    bool                     `json:"verify,omitempty" mapstructure:"verify"`
+	CosignPubKey              string                   `json:"cosign-key,omitempty" mapstructure:"cosign-key"`
+	Arch                      string                   `json:"arch,omitempty" mapstructure:"arch"`
+	Platform                  PlatformSchema           `json:"platform,omitempty" mapstructure:"platform"`
+	SquashFsCompressionConfig []string                 `json:"squash-compression,omitempty" mapstructure:"squash-compression"`
+	SquashFsNoCompression     bool                     `json:"squash-no-compression,omitempty" mapstructure:"squash-no-compression"`
+	UkiMaxEntries             int                      `json:"uki-max-entries,omitempty" mapstructure:"uki-max-entries"`
+	Stages                    map[string][]StageSchema `json:"stages,omitempty" description:"Cloud-init stages to execute"`
+}
+
+// StageSchema defines the stage fields validated by the Kairos configuration schema.
+// Other yip stage fields remain accepted as additional properties.
+type StageSchema struct {
+	Commands []string `json:"commands,omitempty" description:"Commands to execute"`
 }
 
 type PlatformSchema struct {

--- a/schema/validate_test.go
+++ b/schema/validate_test.go
@@ -23,6 +23,21 @@ var _ = Describe("Validate", func() {
 	Context("Validate", func() {
 		var yaml string
 
+		Context("with commands defined as a scalar", func() {
+			BeforeEach(func() {
+				yaml = `#cloud-config
+users:
+  - name: example
+stages:
+  example:
+    - commands: "echo whoops"`
+			})
+
+			It("rejects the invalid stage", func() {
+				Expect(Validate(yaml)).To(MatchError(ContainSubstring("expected array, but got string")))
+			})
+		})
+
 		Context("With a really long config string", func() {
 			BeforeEach(func() {
 				yaml = `#cloud-config


### PR DESCRIPTION
Fixes kairos-io/kairos#3862.

What: add the `stages` shape to the generated Kairos cloud-config schema and validate each stage `commands` field as a list of strings.

Why: `kairos-agent validate` delegates to this schema, but `stages` was absent. A scalar such as `commands: "echo whoops"` therefore passed validation, then yip silently decoded no commands and skipped the stage.

How: keep the stage schema deliberately narrow so existing yip stage fields remain accepted as additional properties, while rejecting the malformed command shape with a focused regression test.

Tested:
- `go test -count=1 ./schema`
- `go vet ./schema`
- `git diff --check upstream/main...HEAD`

The full `go test ./...` suite cannot compile in this container because the TPM simulator dependency requires the missing `openssl/aes.h` development header; the failure is unrelated to these schema-only changes.