### PR TITLE
feat(state): node network addresses + non-UKI autoreset detection

### DIFF
--- a/state/addresses.go
+++ b/state/addresses.go
@@ -1,0 +1,139 @@
+package state
+
+import (
+	"net"
+	"os"
+	"sort"
+	"strings"
+)
+
+// MachineAddress is one of a node's network addresses. It mirrors the Cluster
+// API MachineAddress shape (type + address) so CAPI-adjacent consumers (e.g. an
+// infrastructure provider) can pass it straight through.
+type MachineAddress struct {
+	Type    string `yaml:"type" json:"type"`
+	Address string `yaml:"address" json:"address"`
+}
+
+// Address type values, aligned with the Cluster API MachineAddress vocabulary.
+const (
+	AddressInternalIP = "InternalIP"
+	AddressHostname   = "Hostname"
+	// AddressExternalIP is reserved for a future externally-supplied address that
+	// is not present on any local NIC (e.g. a cloud-assigned public IP). Detection
+	// here only reports NIC-local addresses, but the vocabulary leaves room for it.
+	AddressExternalIP = "ExternalIP"
+)
+
+// excludedIfacePrefixes lists interface-name prefixes whose addresses are NOT the
+// node's own routable addresses: container/CNI networking, VM/virtual bridges,
+// VPN/overlay tunnels, and dummy devices. Everything else that carries a
+// global-unicast IP is reported — including ordinary NICs and real host bridges
+// such as "br0" (a real bridge can legitimately hold the node's primary address;
+// only the docker-style "br-<hex>" bridges are excluded, via the "br-" prefix,
+// not "br").
+//
+// This list is the reviewable policy knob: adjust it rather than the filtering
+// logic. It is deliberately name-based and conservative — when in doubt an
+// interface is INCLUDED, since a missing node address is worse than an extra one.
+var excludedIfacePrefixes = []string{
+	"docker",  // docker0
+	"cni",     // cni0
+	"veth",    // container veth pairs
+	"cali",    // Calico
+	"flannel", // Flannel (flannel.1)
+	"cilium",  // Cilium
+	"kube",    // kube-ipvs0, kube-bridge
+	"nodelocaldns",
+	"br-",       // docker/compose bridges "br-<hex>" (NOT "br0")
+	"virbr",     // libvirt bridges
+	"ovs-",      // Open vSwitch
+	"lxcbr",     // LXC bridge
+	"lxdbr",     // LXD bridge
+	"tunl",      // IPIP tunnels
+	"wg",        // WireGuard
+	"tailscale", // Tailscale
+	"zt",        // ZeroTier
+	"dummy",     // dummy devices
+}
+
+// isExcludedIface reports whether an interface name matches an excluded prefix.
+func isExcludedIface(name string) bool {
+	for _, p := range excludedIfacePrefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// ifaceInfo is the subset of an interface the filter needs. It exists so the
+// filtering policy can be unit-tested without real NICs.
+type ifaceInfo struct {
+	Name     string
+	Up       bool
+	Loopback bool
+	IPs      []net.IP
+}
+
+// filterAddresses applies the reporting policy to a list of interfaces and
+// returns the node's routable addresses (InternalIP), deduplicated and sorted
+// for deterministic output. It is pure: no host I/O.
+func filterAddresses(ifaces []ifaceInfo) []MachineAddress {
+	seen := map[string]struct{}{}
+	var out []MachineAddress
+	for _, ifc := range ifaces {
+		if !ifc.Up || ifc.Loopback || isExcludedIface(ifc.Name) {
+			continue
+		}
+		for _, ip := range ifc.IPs {
+			// Keep global-unicast (this includes RFC1918 private space, which is
+			// typically the node's real LAN address); drop loopback, link-local,
+			// multicast and unspecified.
+			if ip == nil || !ip.IsGlobalUnicast() || ip.IsLinkLocalUnicast() {
+				continue
+			}
+			s := ip.String()
+			if _, dup := seen[s]; dup {
+				continue
+			}
+			seen[s] = struct{}{}
+			out = append(out, MachineAddress{Type: AddressInternalIP, Address: s})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Address < out[j].Address })
+	return out
+}
+
+// DetectAddresses returns the node's current routable network addresses plus its
+// hostname. It is cheap (reads net.Interfaces and os.Hostname) and is NOT cached:
+// addresses change (DHCP, NIC churn) and callers that report them periodically
+// must re-read. Best-effort: on error it returns whatever it has.
+func DetectAddresses() []MachineAddress {
+	var infos []ifaceInfo
+	if ifaces, err := net.Interfaces(); err == nil {
+		for _, ifc := range ifaces {
+			info := ifaceInfo{
+				Name:     ifc.Name,
+				Up:       ifc.Flags&net.FlagUp != 0,
+				Loopback: ifc.Flags&net.FlagLoopback != 0,
+			}
+			addrs, err := ifc.Addrs()
+			if err != nil {
+				continue
+			}
+			for _, a := range addrs {
+				if ipnet, ok := a.(*net.IPNet); ok {
+					info.IPs = append(info.IPs, ipnet.IP)
+				}
+			}
+			infos = append(infos, info)
+		}
+	}
+
+	out := filterAddresses(infos)
+	if hn, err := os.Hostname(); err == nil && hn != "" {
+		out = append(out, MachineAddress{Type: AddressHostname, Address: hn})
+	}
+	return out
+}

--- a/state/addresses_test.go
+++ b/state/addresses_test.go
@@ -1,0 +1,91 @@
+package state
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("filterAddresses", func() {
+	ip := func(s string) net.IP { return net.ParseIP(s) }
+
+	It("reports routable NIC addresses and drops loopback, down, link-local and virtual interfaces", func() {
+		ifaces := []ifaceInfo{
+			{Name: "lo", Up: true, Loopback: true, IPs: []net.IP{ip("127.0.0.1"), ip("::1")}},
+			{Name: "eth0", Up: true, IPs: []net.IP{ip("10.0.10.21"), ip("fe80::1")}}, // routable + link-local
+			{Name: "eth1", Up: false, IPs: []net.IP{ip("10.0.20.5")}},                // down => skip
+			{Name: "docker0", Up: true, IPs: []net.IP{ip("172.17.0.1")}},             // container bridge
+			{Name: "cali123", Up: true, IPs: []net.IP{ip("10.244.1.1")}},             // CNI
+			{Name: "vethabcd", Up: true, IPs: []net.IP{ip("10.244.1.2")}},            // veth pair
+			{Name: "br-9f3a2b", Up: true, IPs: []net.IP{ip("172.18.0.1")}},           // docker/compose bridge
+			{Name: "br0", Up: true, IPs: []net.IP{ip("192.168.50.10")}},              // REAL bridge => keep
+			{Name: "eth2", Up: true, IPs: []net.IP{ip("169.254.1.1")}},               // link-local only => drop
+		}
+
+		got := filterAddresses(ifaces)
+
+		addrs := make([]string, 0, len(got))
+		for _, a := range got {
+			Expect(a.Type).To(Equal(AddressInternalIP))
+			addrs = append(addrs, a.Address)
+		}
+		// Only the real NIC and the real bridge; deterministic sorted order.
+		Expect(addrs).To(Equal([]string{"10.0.10.21", "192.168.50.10"}))
+	})
+
+	It("keeps IPv6 global-unicast and drops IPv6 link-local", func() {
+		got := filterAddresses([]ifaceInfo{
+			{Name: "eth0", Up: true, IPs: []net.IP{ip("2001:db8::5"), ip("fe80::a")}},
+		})
+		Expect(got).To(HaveLen(1))
+		Expect(got[0].Address).To(Equal("2001:db8::5"))
+	})
+
+	It("deduplicates the same IP seen on multiple interfaces", func() {
+		got := filterAddresses([]ifaceInfo{
+			{Name: "eth0", Up: true, IPs: []net.IP{ip("10.0.0.5")}},
+			{Name: "eth0.100", Up: true, IPs: []net.IP{ip("10.0.0.5")}}, // VLAN sub-iface, same IP
+		})
+		Expect(got).To(HaveLen(1))
+	})
+
+	It("returns nothing when there are no routable addresses", func() {
+		got := filterAddresses([]ifaceInfo{
+			{Name: "lo", Up: true, Loopback: true, IPs: []net.IP{ip("127.0.0.1")}},
+			{Name: "cni0", Up: true, IPs: []net.IP{ip("10.244.0.1")}},
+		})
+		Expect(got).To(BeEmpty())
+	})
+})
+
+var _ = DescribeTable("isExcludedIface",
+	func(name string, excluded bool) { Expect(isExcludedIface(name)).To(Equal(excluded)) },
+	Entry("docker0", "docker0", true),
+	Entry("cni0", "cni0", true),
+	Entry("calico veth", "cali1a2b3c", true),
+	Entry("veth pair", "vethabcd", true),
+	Entry("flannel", "flannel.1", true),
+	Entry("compose bridge br-<hex>", "br-9f3a2b", true),
+	Entry("wireguard", "wg0", true),
+	Entry("tailscale", "tailscale0", true),
+	Entry("real NIC eth0", "eth0", false),
+	Entry("predictable NIC enp1s0", "enp1s0", false),
+	Entry("real bridge br0", "br0", false),
+	Entry("bond master bond0", "bond0", false),
+	Entry("VLAN sub-interface", "eth0.100", false),
+)
+
+var _ = Describe("DetectAddresses", func() {
+	It("returns at least the hostname on any host", func() {
+		// Cheap smoke test against the real host: hostname is always present.
+		got := DetectAddresses()
+		var hasHostname bool
+		for _, a := range got {
+			if a.Type == AddressHostname {
+				hasHostname = true
+			}
+		}
+		Expect(hasHostname).To(BeTrue())
+	})
+})

--- a/state/bootstate_test.go
+++ b/state/bootstate_test.go
@@ -1,0 +1,50 @@
+package state
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/twpayne/go-vfs/v4/vfst"
+)
+
+var _ = DescribeTable("getNonUKIBootState",
+	func(cmdline string, want Boot) { Expect(getNonUKIBootState(cmdline)).To(Equal(want)) },
+	Entry("active", "root=LABEL=COS_ACTIVE ro", Active),
+	Entry("passive", "root=LABEL=COS_PASSIVE ro", Passive),
+	Entry("recovery", "root=LABEL=COS_RECOVERY ro", Recovery),
+	Entry("recovery via recovery-mode", "root=/dev/sda2 recovery-mode ro", Recovery),
+	// The statereset boot carries kairos.reset on a COS_RECOVERY command line;
+	// kairos.reset must win => AutoReset, not Recovery.
+	Entry("autoreset (statereset)", "root=LABEL=COS_RECOVERY vga=795 kairos.reset", AutoReset),
+	Entry("livecd", "root=live:LABEL=COS_LIVE ro", LiveCD),
+	Entry("livecd via netboot", "root=/dev/nfs netboot ip=dhcp", LiveCD),
+	// A cmdline with no known marker must NOT be reported as a false "active".
+	Entry("no marker => Unknown", "root=/dev/vda1 ro quiet", Unknown),
+)
+
+var _ = Describe("DetectBootWithVFS", func() {
+	withCmdline := func(cmdline string) *vfst.TestFS {
+		fs, _, err := vfst.NewTestFS(map[string]interface{}{"/proc/cmdline": cmdline})
+		Expect(err).ToNot(HaveOccurred())
+		return fs
+	}
+
+	It("recognises the statereset (autoreset) boot", func() {
+		b, err := DetectBootWithVFS(withCmdline("root=LABEL=COS_RECOVERY kairos.reset"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(b).To(Equal(AutoReset))
+	})
+
+	It("recognises an active boot", func() {
+		b, err := DetectBootWithVFS(withCmdline("root=LABEL=COS_ACTIVE ro"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(b).To(Equal(Active))
+	})
+
+	It("returns an error (and Unknown) when /proc/cmdline is unreadable", func() {
+		fs, _, err := vfst.NewTestFS(map[string]interface{}{})
+		Expect(err).ToNot(HaveOccurred())
+		b, err := DetectBootWithVFS(fs)
+		Expect(err).To(HaveOccurred())
+		Expect(b).To(Equal(Unknown))
+	})
+})

--- a/state/state.go
+++ b/state/state.go
@@ -62,15 +62,16 @@ type EncryptedParts struct {
 }
 
 type Runtime struct {
-	UUID                string          `yaml:"uuid" json:"uuid"`
-	Persistent          PartitionState  `yaml:"persistent" json:"persistent"`
-	Recovery            PartitionState  `yaml:"recovery" json:"recovery"`
-	OEM                 PartitionState  `yaml:"oem" json:"oem"`
-	State               PartitionState  `yaml:"state" json:"state"`
-	EncryptedPartitions EncryptedParts  `yaml:"encrypted_partitions,omitempty" json:"encrypted_partitions,omitempty"`
-	BootState           Boot            `yaml:"boot" json:"boot"`
-	System              sysinfo.SysInfo `yaml:"system" json:"system"`
-	Kairos              Kairos          `yaml:"kairos" json:"kairos"`
+	UUID                string           `yaml:"uuid" json:"uuid"`
+	Persistent          PartitionState   `yaml:"persistent" json:"persistent"`
+	Recovery            PartitionState   `yaml:"recovery" json:"recovery"`
+	OEM                 PartitionState   `yaml:"oem" json:"oem"`
+	State               PartitionState   `yaml:"state" json:"state"`
+	EncryptedPartitions EncryptedParts   `yaml:"encrypted_partitions,omitempty" json:"encrypted_partitions,omitempty"`
+	BootState           Boot             `yaml:"boot" json:"boot"`
+	System              sysinfo.SysInfo  `yaml:"system" json:"system"`
+	Addresses           []MachineAddress `yaml:"addresses,omitempty" json:"addresses,omitempty"`
+	Kairos              Kairos           `yaml:"kairos" json:"kairos"`
 }
 
 type FndMnt struct {
@@ -131,6 +132,15 @@ func detectPartitionByFindmnt(b *block.Partition) PartitionState {
 	}
 }
 
+// DetectBoot returns the current boot state, UKI-aware: it inspects
+// /proc/cmdline and, on a UKI system, the EFI current-entry file. It is
+// lightweight (no partition or hardware probing, unlike NewRuntime) and returns
+// Unknown when it cannot classify. Useful for callers — such as fleet agents —
+// that only need the boot state.
+func DetectBoot(logger zerolog.Logger) Boot {
+	return detectBoot(logger)
+}
+
 func detectBoot(logger zerolog.Logger) Boot {
 	logger.Debug().Msg("detecting boot state")
 	cmdline, err := os.ReadFile("/proc/cmdline")
@@ -186,6 +196,12 @@ func getUKIBootState(logger zerolog.Logger) Boot {
 
 func getNonUKIBootState(cmdline string) Boot {
 	switch {
+	// The automatic state-reset boot (the statereset GRUB entry) boots the
+	// recovery system with `kairos.reset` on the command line; match it before
+	// the COS_RECOVERY case below, which it also satisfies. The UKI path already
+	// maps the `statereset` boot entry to AutoReset in getUKIBootState.
+	case strings.Contains(cmdline, "kairos.reset"):
+		return AutoReset
 	case strings.Contains(cmdline, "COS_ACTIVE"):
 		return Active
 	case strings.Contains(cmdline, "COS_PASSIVE"):
@@ -234,6 +250,10 @@ func DetectBootWithVFS(fs fs.KairosFS) (Boot, error) {
 	}
 	cmdlineS := string(cmdline)
 	switch {
+	// See getNonUKIBootState: the statereset boot carries `kairos.reset` on a
+	// recovery command line, so match it first.
+	case strings.Contains(cmdlineS, "kairos.reset"):
+		return AutoReset, nil
 	case strings.Contains(cmdlineS, "COS_ACTIVE"):
 		return Active, nil
 	case strings.Contains(cmdlineS, "COS_PASSIVE"):
@@ -379,6 +399,7 @@ func NewRuntimeWithLogger(logger zerolog.Logger) (Runtime, error) {
 	runtime := &Runtime{
 		BootState: detectBoot(logger),
 		UUID:      utils.UUID(),
+		Addresses: DetectAddresses(),
 	}
 
 	detectSystem(runtime)

--- a/state/state_suite_test.go
+++ b/state/state_suite_test.go
@@ -1,0 +1,13 @@
+package state
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestState(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "State Suite")
+}


### PR DESCRIPTION
## Summary

Adds the reusable machine-state producers a fleet agent — and a CAPI infrastructure provider built on it — needs, so they don't reimplement them in their own repos. Groundwork for kairos-io/kairos#4253 (companion to AuroraBoot #655 and kairos-agent #1317); split out of #1317 per review feedback that this logic belongs in the SDK, not the agent.

## What's here

- **`state.DetectAddresses()`** — the node's routable network addresses (`InternalIP`) plus its hostname, as `[]MachineAddress` (mirrors the Cluster API `MachineAddress` shape: `type` + `address`). Container/CNI/virtual/VPN interfaces are filtered out by name prefix (`docker*`, `cni*`, `cali*`, `veth*`, `br-<hex>`, `virbr*`, `wg*`, `tailscale*`, …) along with loopback/link-local IPs; ordinary NICs **and real bridges (`br0`)** are kept — a real bridge can hold the node's primary address (only docker-style `br-<hex>` is excluded). Output is deduplicated and sorted (deterministic). It's cheap and not cached, so callers that report periodically (DHCP changes) can re-read. `Runtime` gains an `Addresses` field populated by it, filling the gap where `sysinfo.NetworkDevice` has NIC hardware but no IPs.
- **`state.DetectBoot(logger)`** — exported, lightweight, **UKI-aware** boot-state detector (reads `/proc/cmdline` and, on UKI, the EFI current entry). Lets callers that only need the boot state avoid `NewRuntime`'s partition/hardware probing.
- **Non-UKI autoreset fix** — `getNonUKIBootState` and `DetectBootWithVFS` now map a `kairos.reset` command line to `AutoReset` (the automatic state-reset boot). The UKI path already mapped the `statereset` entry; the grub path did not, so a statereset boot on a non-UKI node was misreported as `Recovery`.

## The reviewable knob

Per the discussion on kairos-io/kairos#4253 (bridges/veth/bonds), the interface exclusion set is a single documented `var` (`excludedIfacePrefixes`) with a unit-test table, deliberately **include-by-default**. Adjust that list rather than the filtering logic.

## Tests

Adds the `state` package's first test suite (Ginkgo): the address filter (real vs container bridges, IPv6 link-local, dedup, deterministic order), `isExcludedIface`, and the boot-state classification — including the new autoreset case and, importantly, that an unrecognised command line yields `Unknown` rather than a false `active`. Also validated `DetectAddresses()` against a real multi-bridge host: it kept the routable NIC/bridge IP and dropped docker0 / virbr0 / tailscale0 / `br-<hex>` / loopback.
