### PR TITLE
feat: let SetFirmwarePartitions honor a configured EFI size

### DIFF
--- a/types/partitions/partitions.go
+++ b/types/partitions/partitions.go
@@ -30,8 +30,11 @@ type Disk struct {
 }
 
 type ElementalPartitions struct {
-	BIOS       *Partition `yaml:"-" json:"-"` // We dont want marshal/unmarshal this field
-	EFI        *Partition `yaml:"-" json:"-"` // We dont want marshal/unmarshal this field
+	BIOS *Partition `yaml:"-" json:"-"` // We dont want marshal/unmarshal this field
+	// EFI is not serialized (yaml/json "-"), but its size may be set from
+	// config (e.g. install.partitions.efi.size) via mapstructure, so platforms
+	// that need a larger ESP (e.g. Jetson Thor) can request one.
+	EFI        *Partition `yaml:"-" json:"-" mapstructure:"efi"`
 	OEM        *Partition `yaml:"oem,omitempty" mapstructure:"oem" json:"oem,omitempty"`
 	Recovery   *Partition `yaml:"recovery,omitempty" mapstructure:"recovery" json:"recovery,omitempty"`
 	State      *Partition `yaml:"state,omitempty" mapstructure:"state" json:"state,omitempty"`
@@ -128,9 +131,18 @@ func (ep *ElementalPartitions) PartitionsByMountPoint(descending bool, excludes 
 // SetFirmwarePartitions sets firmware partitions for a given firmware and partition table type.
 func (ep *ElementalPartitions) SetFirmwarePartitions(firmware string, partTable string) error {
 	if firmware == constants.EFI && partTable == constants.GPT {
+		// Preserve a size the caller already set (e.g. from
+		// install.partitions.efi.size in the config) and only fall back to the
+		// default when it is unset. Some platforms (e.g. Jetson Thor, which
+		// stages a ~29MB UEFI firmware capsule on the ESP) need a larger ESP
+		// than the 64MiB default.
+		efiSize := constants.EfiSize
+		if ep.EFI != nil && ep.EFI.Size != 0 {
+			efiSize = ep.EFI.Size
+		}
 		ep.EFI = &Partition{
 			FilesystemLabel: constants.EfiLabel,
-			Size:            constants.EfiSize,
+			Size:            efiSize,
 			Name:            constants.EfiPartName,
 			FS:              constants.EfiFs,
 			MountPoint:      constants.EfiDirTransient,

--- a/types/partitions/partitions_test.go
+++ b/types/partitions/partitions_test.go
@@ -1,0 +1,49 @@
+package partitions
+
+import (
+	"testing"
+
+	"github.com/kairos-io/kairos-sdk/constants"
+)
+
+func TestSetFirmwarePartitionsEFIDefaultSize(t *testing.T) {
+	ep := &ElementalPartitions{}
+	if err := ep.SetFirmwarePartitions(constants.EFI, constants.GPT); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ep.EFI == nil {
+		t.Fatal("expected an EFI partition to be set")
+	}
+	if ep.EFI.Size != constants.EfiSize {
+		t.Errorf("expected default EFI size %d, got %d", constants.EfiSize, ep.EFI.Size)
+	}
+}
+
+func TestSetFirmwarePartitionsEFIPreservesConfiguredSize(t *testing.T) {
+	const configured = uint(128)
+	ep := &ElementalPartitions{EFI: &Partition{Size: configured}}
+	if err := ep.SetFirmwarePartitions(constants.EFI, constants.GPT); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ep.EFI.Size != configured {
+		t.Errorf("expected configured EFI size %d to be preserved, got %d", configured, ep.EFI.Size)
+	}
+	// The rest of the fields must still be forced to their fixed values, since
+	// boot relies on the label/name/mountpoint being predictable.
+	if ep.EFI.FilesystemLabel != constants.EfiLabel {
+		t.Errorf("expected label %q, got %q", constants.EfiLabel, ep.EFI.FilesystemLabel)
+	}
+	if ep.EFI.MountPoint != constants.EfiDirTransient {
+		t.Errorf("expected mountpoint %q, got %q", constants.EfiDirTransient, ep.EFI.MountPoint)
+	}
+}
+
+func TestSetFirmwarePartitionsEFIZeroFallsBackToDefault(t *testing.T) {
+	ep := &ElementalPartitions{EFI: &Partition{Size: 0}}
+	if err := ep.SetFirmwarePartitions(constants.EFI, constants.GPT); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ep.EFI.Size != constants.EfiSize {
+		t.Errorf("expected fallback to default %d for zero size, got %d", constants.EfiSize, ep.EFI.Size)
+	}
+}


### PR DESCRIPTION
The EFI/ESP size was hardcoded to the 64MiB default, ignoring any size the caller set. Preserve a non-zero preset size and only fall back to the default when unset; other fixed fields (label, name, mountpoint, flags) stay forced so boot stays predictable. Also add an explicit mapstructure tag to the EFI field so install.partitions.efi.size binds deterministically (it is still excluded from yaml/json serialization).

Motivated by Jetson Thor, which stages a ~29MB UEFI firmware capsule on the ESP and needs more than 64MiB of headroom.

Refs kairos-io/kairos#4228 https://github.com/kairos-io/kairos-init/pull/411